### PR TITLE
Example domain change; Requirements in separate doc

### DIFF
--- a/BRIDGE.md
+++ b/BRIDGE.md
@@ -6,11 +6,11 @@
 
 Simple plug-n-play server for supporting [Lightning Address](https://lightningaddress.com) protocol.
 
-> At the end of this flow you will be able to receive payments at `any_name@domain.com`.
+> At the end of this flow you will be able to receive payments at `any_name@example.org`.
 
 ## General
 
-A server that allows you to receive payments at `yourname@yourdomain.com` noncustodially. The Bridge Server serves the necessary JSON and then uses RPC calls to connect to your node and fetch invoices on demand.
+A server that allows you to receive payments at `yourname@yourexample.org` noncustodially. The Bridge Server serves the necessary JSON and then uses RPC calls to connect to your node and fetch invoices on demand.
 
 **You don't have to do anything besides buying a domain and setting up some DNS records. HTTPS will be provided automatically for you.**
 
@@ -23,54 +23,6 @@ At the moment `lightningaddr` supports the following Lightning Network backends:
 
 ## Setup Guide
 
-Considering you own the `domain.com` domain, you need to set up these DNS records:
+See [Domain requirements](./REQUIREMENTS.md#Domain) for domain (DNS) setup.
 
-* A domain.com -> `5.2.67.89`
-
-### To use with `c-lightning` and `Sparko`:
-
-* TXT `_kind`.domain.com -> sparko
-* TXT `_host`.domain.com -> http(s)://`your-ip-or-whatever.com`/rpc
-* TXT `_key`.domain.com -> `key_with_permission_to_method_invoicewithdescriptionhash`
-
-### To use with LND:
-
-* TXT `_kind`.domain.com -> lnd
-* TXT `_host`.domain.com -> http(s)://`your-ip-or-whatever.com`
-* TXT `_macaroon`.domain.com -> `macaroon_as_base64`
-
-### Optional extras:
-
-If you want to specify a description for the Lightning Address payment screen:
-
-* TXT `_description`.domain.com -> free text
-
-If you want to specify an image for the Lightning Address payment screen:
-
-* TXT `_image`.domain.com -> https://url.to/image
-
-If you want to receive comments through the Lightning Address:
-
-* TXT `_webhook`.domain.com -> https://url.to/receive/webhook
-
-The webhook will contain a JSON object like the one below:
-
-```json
-{
-  "comment": "...",
-  "pr": "lnbc....",
-  "amount:": 12345
-}
-```
-
-> NOTE: Amount is in millisatoshis. The webhook is dispatched when an invoice is generated, not when it is paid, since we don't know when (or if) it was paid.
-
-If you use a self-signed certificate and want that to be checked:
-
-* TXT `_cert`.domain.com -> -----BEGIN CERTIFICATE----- MIQT...TQIM -----END CERTIFICATE-----
-
-If you want to reuse the domain root to redirect to elsewhere (maybe to the www subdomain?):
-
-TXT `_redirect`.domain.com -> https://www.domain.com/
-
-# Now you can receive payments at `any_name@domain.com`.
+Setup instructions for the Bridge server WIP.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more information check out the website: [lightningaddress.com](https://light
 
 ## Developers
 
-If you are a developer aiming to introduce support for Lightning Addresses in your application, wallet, check the [DIY](./DIY.md) section.
+If you are a developer aiming to introduce support for Lightning Addresses in your application, wallet, check the [DIY](./DIY.md) section. [REQUIREMENTS](./REQUIREMENTS.md) has information on requirements (for both sending app and receiving domain).
 
 ## Bridge Server
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,0 +1,64 @@
+![](https://i.imgur.com/uwHlWPC.png)
+
+# `lightningaddr` Requirements
+
+Requirements for using the [Lightning Address](https://lightningaddress.com) protocol.
+
+
+## Sending app
+
+For the app sending payments to user@example.org, the following requirements apply:
+* App needs LNURL-Pay support
+* Verify the lightningaddress domain using HTTPS
+
+## Receiving domain
+
+Considering you own the `example.org` domain, you need to set up these DNS records:
+
+* A example.org -> `5.2.67.89`
+
+### To use with `c-lightning` and `Sparko`:
+
+* TXT `_kind`.example.org -> sparko
+* TXT `_host`.example.org -> http(s)://`your-ip-or-whatever.com`/rpc
+* TXT `_key`.example.org -> `key_with_permission_to_method_invoicewithdescriptionhash`
+
+### To use with LND:
+
+* TXT `_kind`.example.org -> lnd
+* TXT `_host`.example.org -> http(s)://`your-ip-or-whatever.com`
+* TXT `_macaroon`.example.org -> `macaroon_as_base64`
+
+### Optional extras:
+
+If you want to specify a description for the Lightning Address payment screen:
+
+* TXT `_description`.example.org -> free text
+
+If you want to specify an image for the Lightning Address payment screen:
+
+* TXT `_image`.example.org -> https://url.to/image
+
+If you want to receive comments through the Lightning Address:
+
+* TXT `_webhook`.example.org -> https://url.to/receive/webhook
+
+The webhook will contain a JSON object like the one below:
+
+```json
+{
+  "comment": "...",
+  "pr": "lnbc....",
+  "amount:": 12345
+}
+```
+
+> NOTE: Amount is in millisatoshis. The webhook is dispatched when an invoice is generated, not when it is paid, since we don't know when (or if) it was paid.
+
+If you use a self-signed certificate and want that to be checked:
+
+* TXT `_cert`.example.org -> -----BEGIN CERTIFICATE----- MIQT...TQIM -----END CERTIFICATE-----
+
+If you want to reuse the domain root to redirect to elsewhere (maybe to the www subdomain?):
+
+TXT `_redirect`.example.org -> https://www.example.org/

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -5,6 +5,9 @@
 Requirements for using the [Lightning Address](https://lightningaddress.com) protocol.
 
 
+## Reserved keywords / user names
+* `index` holds an optional list of usernames for this domain
+
 ## Sending app
 
 For the app sending payments to user@example.org, the following requirements apply:
@@ -52,6 +55,10 @@ The webhook will contain a JSON object like the one below:
   "amount:": 12345
 }
 ```
+
+If you want an index of users:
+
+* Add a plaintext file `index` in the lnurlp folder, with one user per line. Comments allowed using #-characters.
 
 > NOTE: Amount is in millisatoshis. The webhook is dispatched when an invoice is generated, not when it is paid, since we don't know when (or if) it was paid.
 


### PR DESCRIPTION
Changed example domain to example.org

Moved requirements to separate REQUIREMENTS document, I feel the instructions in BRIDGE were incorrectly placed, having a separate requirements document makes more sense to me.