### PR TITLE
Add alby to other parts of the site

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -347,7 +347,6 @@ const SATDRESS_SERVERS = [
   {
     urlLink: 'https://tinytip.me',
     urlText: '@tinytip.me',
-    
   },
   {
     urlLink: 'https://sats.pm',
@@ -356,6 +355,10 @@ const SATDRESS_SERVERS = [
   {
     urlLink: 'https://lnpay.cz',
     urlText: '@lnpay.cz',
+  },
+  {
+    urlLink: 'https://getalby.com',
+    urlText: '@getalby.com',
   },
 ];
 

--- a/components/hero.js
+++ b/components/hero.js
@@ -257,6 +257,7 @@ export class Hero extends PureComponent {
               <LoopedTextPart>bitrefill.me</LoopedTextPart>
               <LoopedTextPart>fbtc.me</LoopedTextPart>
               <LoopedTextPart>lnmarkets.com</LoopedTextPart>
+  						<LoopedTextPart>getalby.com</LoopedTextPart>
             </TextLoop>
           </LoopWrapper>
         </Fade>

--- a/components/providers.js
+++ b/components/providers.js
@@ -204,6 +204,11 @@ const BTCPayImage = styled.img`
   align-self: center;
 `;
 
+const AlbyImage = styled.img`
+  width: 50px;
+  border-radius: 5%;
+`;
+
 const Bold = styled.span`
   font-weight: 600;
   letter-spacing: -0.5px;
@@ -313,6 +318,13 @@ export const Providers = () => (
           </ImageWrapper>
           <ProviderSignUpButton target="_blank" href="https://galoy.io/bitcoin-beach/">Download Wallet</ProviderSignUpButton>
         </ProviderCard>
+			  <ProviderCard>
+					<ImageWrapper>
+						<AlbyImage src={'/images/alby.png'} alt="Alby" />
+						<DomainURL>you@getalby.com</DomainURL>
+					</ImageWrapper>
+					<ProviderSignUpButton target="_blank" href="https://getalby.com">Open Alby</ProviderSignUpButton>
+				</ProviderCard>
         <ProviderCard>
           <ImageWrapper>
             <BTCPayImage src={'/images/noah.svg'} alt="Noah" style={{ width: '115px' }} />


### PR DESCRIPTION
In my previous PR #30 we decided to leave Alby out of all the parts of the site until we made it easier for users to get their @getalby.com ln address. We have improved this process so I am now adding it back in. Thanks!