### PR TITLE
Remove ln.fitti.io

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -333,10 +333,6 @@ const SATDRESS_SERVERS = [
     urlText: '@btcadresse.de',
   },
   {
-    urlLink: 'https://ln.fitti.io/',
-    urlText: '@ln.fitti.io',
-  },
-  {
     urlLink: 'https://bitmia.com',
     urlText: '@bitmia.com',
   },


### PR DESCRIPTION
The site is down due to suspected hardware failure. It was essentially unused, so I have no intention of bringing it back and maintaining it.