### PR TITLE
Put https:// in front of lnaddress.com

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -357,7 +357,7 @@ const SATDRESS_SERVERS = [
     urlText: '@getalby.com',
   },
   {
-    urlLink: 'lnaddress.com',
+    urlLink: 'https://lnaddress.com',
     urlText: '@lnaddress.com',
   },
   {


### PR DESCRIPTION
Currently it redirects to https://lightningaddress.com/lnaddress.com and gives an error instead of redirecting to lnaddress.com