### PR TITLE
Add Pouch.ph & Pouch Lite apps to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ _Bitcoin Lightning wallets that support sending and receiving to **Lightning Add
 | [@LightningTipBot](https://github.com/LightningTipBot/LightningTipBot) | ☑️         | ☑️         |
 | [Muun](https://muun.com/)                                         |           |           |
 | [Phoenix](https://phoenix.acinq.co/)                              | ☑️         |   ----    |
+| [Pouch Lite](https://pouch.ph/lite)                               | ☑️         |   ☑️       |
+| [Pouch.ph](https://pouch.ph/)                                     | ☑️         |   ☑️       |
 | [SBW](https://sbw.app/)                                           | ☑️         |   ----    |
 | [Spark Wallet](https://sparkwallet.io/)                           |  ☑️        |   ☑️       |
 | [ThunderHub](https://github.com/apotdevin/thunderhub)             | ☑️         |   ----    |


### PR DESCRIPTION
Pouch Lite is like wallet of satoshi, except based out of El Salvador.

Pouch.ph is the Philippine Peso lightning wallet with PHP banking rails (Strike.me for the Philippines)