### PR TITLE
Add PHP Lightning Address in BRIDGE_SERVERS

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -407,6 +407,11 @@ const BRIDGE_SERVERS = [
     urlText: 'LnMe',
     description: 'Self-hosted Lightning Address server and personal payment page.',
   },
+  {
+    urlLink: 'https://github.com/Bashy/phplightningaddress',
+    urlText: 'PHP Lightning Address',
+    description: 'Lightning Address on your domain just by hosting a php script.',
+  },
 ];
 
 const WALLETS = [


### PR DESCRIPTION
I've published my php script that allows to get a personal lightning address for people who own a website, this does not require any shell/cli access and thus is an easy way to access to lightning addresses.