### PR TITLE
chore: remove defunct btcaddresse.de and lnaddress.com

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -329,10 +329,6 @@ const SATDRESS_SERVERS = [
     urlText: '@payaddress.co',
   },
   {
-    urlLink: 'https://btcadresse.de',
-    urlText: '@btcadresse.de',
-  },
-  {
     urlLink: 'https://sats.pm',
     urlText: '@sats.pm',
   },
@@ -343,10 +339,6 @@ const SATDRESS_SERVERS = [
   {
     urlLink: 'https://lnpay.cz',
     urlText: '@lnpay.cz',
-  },
-  {
-    urlLink: 'https://lnaddress.com',
-    urlText: '@lnaddress.com',
   },
   {
     urlLink: 'https://lnaddress.me/',


### PR DESCRIPTION
I was checking out the providers and noticed that these two seem to be offline. Not sure what the general feeling is about how long to leave up defunct sites in case it's just a short downtime, but it doesn't look great to have dead providers.