### PR TITLE
chore: mark receiving support for Blixt Wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ _Bitcoin Lightning wallets that support sending and receiving to **Lightning Add
 | [Bitnob](https://bitnob.com)                                      | ☑️         | ☑️         |
 | [Blink (Bitcoin Beach Wallet)](https://blink.sv/)                 | ☑️         | ☑️         |
 | [BitcoLi wallet](https://bitcoli.com/)                            | ☑️         | ☑️         |
-| [Blixt](https://blixtwallet.github.io/)                           | ☑️         | [WIP](https://github.com/hsjoberg/lightning-box/blob/master/README.md)     |
+| [Blixt](https://blixtwallet.github.io/)                           | ☑️         | ☑️         |
 | [BlueWallet](https://bluewallet.io/)                              | ☑️         |   ----    |
 | [Bookmark.org](https://bookmark.org/)                             | ----      | ☑️         |
 | [Bottlepay](https://bottlepay.com/)                               | ☑️       | ☑️       |


### PR DESCRIPTION
Hey. Since [v0.6.9-420](https://github.com/hsjoberg/blixt-wallet/releases/tag/v0.6.9-420) Blixt supports receiving via Lightning Address on Android. This PR updates the table to reflect that.

Cheers
Hampus