### PR TITLE
Add Piggy wallet to supported Lightning wallets list

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ _Bitcoin Lightning wallets that support sending and receiving to **Lightning Add
 | [Numeraire](https://numeraire.tech/)                              | ☑️         | ☑️         |
 | [Oak Node](https://oak-node.net)                                  | ☑️        | ----      |
 | [Phoenix](https://phoenix.acinq.co/)                              | ☑️        | ----      |
+| [Piggy](https://pig.gy/)                                          | ☑️        | ☑️        |
 | [Pouch.ph](https://pouch.ph/)                                     | ☑️        | ☑️        |
 | [Satoshi Lightning](https://vipsats.app)                          | ☑️        | ☑️        |
 | [SBW](https://sbw.app/)                                           | ☑️        | ----      |


### PR DESCRIPTION
Included Piggy (https://pig.gy/) in the table of Bitcoin Lightning wallets that support sending and receiving to Lightning Addresses.