### PR TITLE
Update SparkMoneyBot image width to 45px

### DIFF
--- a/components/providers.js
+++ b/components/providers.js
@@ -423,7 +423,7 @@ const PROVIDERS = [
   {
     name: "@SparkMoneyBot",
     image: "/images/smbicon192.png",
-    imageStyle: { width: "192px" },
+    imageStyle: { width: "45px" },
     lightningAddressDomain: "sparkmoneybot.com",
     url: "https://t.me/sparkmoneybot",
     buttonText: "Open Telegram",


### PR DESCRIPTION
Changed the imageStyle width for the @SparkMoneyBot provider from 192px to 45px to broken UI because of icon sizing.
<img width="571" height="221" alt="Screenshot 2025-11-12 at 10 43 10" src="https://github.com/user-attachments/assets/0f443d6f-7651-4819-ba82-edbe710b9d6e" />
<img width="570" height="511" alt="Screenshot 2025-11-12 at 10 43 30" src="https://github.com/user-attachments/assets/133c4d1a-aa47-45a7-8590-f21d92133bcd" />
