### PR TITLE
Add Rizful to supported wallets list

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ _Bitcoin Lightning wallets that support sending and receiving to **Lightning Add
 | [Phoenix](https://phoenix.acinq.co/)                              | ☑️        | ----      |
 | [Piggy](https://pig.gy/)                                          | ☑️        | ☑️        |
 | [Pouch.ph](https://pouch.ph/)                                     | ☑️        | ☑️        |
+| [Rizful](https://rizful.com/)                                      | ☑️        | ☑️        |
 | [Satoshi Lightning](https://vipsats.app)                          | ☑️        | ☑️        |
 | [SBW](https://sbw.app/)                                           | ☑️        | ----      |
 | [Spark Money Bot](https://sparkmoneybot.com/)                     | WIP       | ☑️        |


### PR DESCRIPTION
Adds Rizful (https://rizful.com/) with sending and receiving support.
