### PR TITLE
fix: add rel="noopener noreferrer" to target="_blank" links

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -588,7 +588,7 @@ export const Community = () => (
                 style={wallet.imageStyle || {}}
               />
             </ImageWrapper>
-            <CommunitySignUpButton target="_blank" href={wallet.url}>
+            <CommunitySignUpButton target="_blank" rel="noopener noreferrer" href={wallet.url}>
               {wallet.downloadText}
             </CommunitySignUpButton>
           </CommunityCard>
@@ -614,7 +614,7 @@ export const Community = () => (
           </CommunityDescriptionSmall>
           <CommunityListWrapper>
             {SATDRESS_SERVERS.map((item) => (
-              <Link key={item.urlText} href={item.urlLink} target="_blank">
+              <Link key={item.urlText} href={item.urlLink} target="_blank" rel="noopener noreferrer">
                 {item.urlText}
               </Link>
             ))}
@@ -626,7 +626,7 @@ export const Community = () => (
           <CommunityVerticalListWrapper>
             {BRIDGE_SERVERS.map((item) => (
               <VerticalLinkWrapper key={item.urlText}>
-                <VerticalLink href={item.urlLink} target="_blank">
+                <VerticalLink href={item.urlLink} target="_blank" rel="noopener noreferrer">
                   {item.urlText}
                 </VerticalLink>
                 <VerticalLinkDescription>

--- a/components/community.js
+++ b/components/community.js
@@ -597,6 +597,7 @@ export const Community = () => (
           <CTASecondary
             href="https://github.com/andrerfneves/lightning-address/blob/master/README.md#wallets-supported"
             target="_blank"
+            rel="noopener noreferrer"
           >
             View list of supported Wallets
           </CTASecondary>

--- a/components/footer.js
+++ b/components/footer.js
@@ -276,7 +276,7 @@ export const Footer = () => (
           <Column key={col.title}>
             <ColumnTitle>{col.title}</ColumnTitle>
             {(col.items || []).map((item) => (
-              <ColumnItem key={item.link} href={item.link} target="_blank">
+              <ColumnItem key={item.link} href={item.link} target="_blank" rel="noopener noreferrer">
                 {item.title}
               </ColumnItem>
             ))}

--- a/components/hero.js
+++ b/components/hero.js
@@ -320,11 +320,11 @@ export function Hero() {
         >
           <CTAWrapper>
             <CTAPrimary href="#providers">Get a Lightning Address</CTAPrimary>
-            <CTASecondary href="https://github.com/andrerfneves/lightning-address/blob/master/README.md" target="_blank">Read Documentation</CTASecondary>
+            <CTASecondary href="https://github.com/andrerfneves/lightning-address/blob/master/README.md" target="_blank" rel="noopener noreferrer">Read Documentation</CTASecondary>
           </CTAWrapper>
           <LicenseWrapper>
             <LicenseText>License: MIT</LicenseText>
-            <LicenseLink href='https://github.com/andrerfneves/lightning-address/blob/master/LICENSE.md' target='_blank'>GitHub</LicenseLink>
+            <LicenseLink href='https://github.com/andrerfneves/lightning-address/blob/master/LICENSE.md' target='_blank' rel="noopener noreferrer">GitHub</LicenseLink>
           </LicenseWrapper>
         </HeroSection>
       )}

--- a/components/paths.js
+++ b/components/paths.js
@@ -192,7 +192,7 @@ export const Paths = () => (
           <PathsCardDescription>
             {benefit.description}
           </PathsCardDescription>
-          <PathsCardButton target={benefit.isInternal ? '' : '_blank'} href={benefit.link} isSecondary={benefit.isSecondary}>
+          <PathsCardButton target={benefit.isInternal ? '' : '_blank'} href={benefit.link} isSecondary={benefit.isSecondary} rel={benefit.isInternal ? '' : 'noopener noreferrer'}>
             {benefit.linkText}
           </PathsCardButton>
         </PathsCard>

--- a/components/providers.js
+++ b/components/providers.js
@@ -452,6 +452,7 @@ export const Providers = () => (
             <ProviderSignUpButton
               isDisabled={provider.comingSoon || false}
               target="_blank"
+              rel="noopener noreferrer"
               href={provider.url}
             >
               {provider.buttonText || `Open ${provider.name}`}


### PR DESCRIPTION
## Summary

Links that use `target="_blank"` without `rel="noopener noreferrer"` allow the opened page to access `window.opener`, which is a known security risk (reverse tabnabbing).

This PR adds the missing `rel` attribute to all external links across the site.

### Changes
- `components/hero.js` — CTASecondary and LicenseLink
- `components/paths.js` — PathsCardButton (external links only)
- `components/providers.js` — ProviderSignUpButton
- `components/community.js` — CommunitySignUpButton, Link, VerticalLink
- `components/footer.js` — ColumnItem

### Verification
- No visual or behavioral changes
- All external links now open safely in new tabs