### PR TITLE
refactor: remove unused Link styled component in hero

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -113,18 +113,6 @@ const LoopedTextPart = styled.span`
   `}
 `;
 
-const Link = styled.a`
-  color: #666666;
-  font-weight: 400;
-  text-decoration: none;
-  letter-spacing: -0.5px;
-
-  &:hover {
-    color: #0070f3;
-    border-color: transparent;
-  }
-`;
-
 const CTAWrapper = styled.div`
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

The  styled component was defined in `components/hero.js` but never used in the rendered JSX. This PR removes the dead code.

### Changes
- Removed unused `const Link = styled.a` block from `components/hero.js`

### Verification
- No visual or behavioral changes
- The component still compiles and builds successfully