### PR TITLE
fix: avoid rendering empty rel/target on internal anchor links

### DIFF
--- a/components/paths.js
+++ b/components/paths.js
@@ -192,9 +192,15 @@ export const Paths = () => (
           <PathsCardDescription>
             {benefit.description}
           </PathsCardDescription>
-          <PathsCardButton target={benefit.isInternal ? '' : '_blank'} href={benefit.link} isSecondary={benefit.isSecondary} rel={benefit.isInternal ? '' : 'noopener noreferrer'}>
-            {benefit.linkText}
-          </PathsCardButton>
+          {benefit.isInternal ? (
+            <PathsCardButton href={benefit.link} isSecondary={benefit.isSecondary}>
+              {benefit.linkText}
+            </PathsCardButton>
+          ) : (
+            <PathsCardButton href={benefit.link} isSecondary={benefit.isSecondary} target="_blank" rel="noopener noreferrer">
+              {benefit.linkText}
+            </PathsCardButton>
+          )}
         </PathsCard>
       ))}
     </PathsCardGrid>


### PR DESCRIPTION
## Summary

The <code>PathsCardButton</code> in <code>components/paths.js</code> was conditionally rendering <code>target=&quot;&quot;</code> and <code>rel=&quot;&quot;</code> for internal links, which produces invalid HTML attributes. This change only renders <code>target=&quot;_blank&quot;</code> and <code>rel=&quot;noopener noreferrer&quot;</code> for external links.

## Changes

- Conditionally render <code>target</code> and <code>rel</code> only on external links in <code>components/paths.js</code>

## Verification

- <code>npm run build</code> passes successfully
- No visual changes; purely an HTML validity fix