### PR TITLE
refactor: remove unused isDisabled prop styling and comingSoon fields

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -140,11 +140,9 @@ const CommunitySignUpButton = styled.a`
   text-decoration: none;
   background-color: #0070f3;
   box-shadow: 0 4px 14px 0 rgb(0 118 255 / 39%);
-  opacity: ${({ isDisabled }) => (isDisabled ? "0.5" : "1")};
 
   &:hover {
-    background: ${({ isDisabled }) =>
-      isDisabled ? "#0070f3" : "rgba(0,118,255,0.9)"};
+    background: rgba(0,118,255,0.9);
     box-shadow: 0 6px 20px rgb(0 118 255 / 23%);
   }
 

--- a/components/providers.js
+++ b/components/providers.js
@@ -181,11 +181,9 @@ const ProviderSignUpButton = styled.a`
   text-decoration: none;
   background-color: #0070f3;
   box-shadow: 0 4px 14px 0 rgb(0 118 255 / 39%);
-  opacity: ${({ isDisabled }) => (isDisabled ? "0.5" : "1")};
 
   &:hover {
-    background: ${({ isDisabled }) =>
-      isDisabled ? "#0070f3" : "rgba(0,118,255,0.9)"};
+    background: rgba(0,118,255,0.9);
     box-shadow: 0 6px 20px rgb(0 118 255 / 23%);
   }
 
@@ -320,7 +318,6 @@ const PROVIDERS = [
     lightningAddressDomain: "noah.me",
     url: "https://app.noah.com",
     buttonText: "Claim Address",
-    comingSoon: false,
   },
   {
     name: "Bitnob",
@@ -337,7 +334,6 @@ const PROVIDERS = [
     lightningAddressDomain: "8333.mobi",
     url: "https://8333.mobi",
     buttonText: "Dial Machankura",
-    comingSoon: false,
   },
   {
     name: "Mash",
@@ -458,7 +454,6 @@ export const Providers = () => (
               <DomainURL>you@{provider.lightningAddressDomain}</DomainURL>
             </ImageWrapper>
             <ProviderSignUpButton
-              isDisabled={provider.comingSoon || false}
               target="_blank"
               rel="noopener noreferrer"
               href={provider.url}


### PR DESCRIPTION
## Summary

Both <code>CommunitySignUpButton</code> and <code>ProviderSignUpButton</code> defined <code>isDisabled</code> prop styling that was never meaningfully used: <code>community.js</code> never passed the prop, and <code>providers.js</code> always passed <code>false</code> because every provider entry has <code>comingSoon: false</code> or omits the field entirely. This removes the dead prop styling and the redundant <code>comingSoon</code> fields from the data arrays.

## Changes

- Remove <code>isDisabled</code> opacity and hover logic from <code>CommunitySignUpButton</code>
- Remove <code>isDisabled</code> opacity and hover logic from <code>ProviderSignUpButton</code>
- Remove <code>isDisabled={provider.comingSoon || false}</code> from JSX
- Remove redundant <code>comingSoon: false</code> entries from <code>PROVIDERS</code> array

## Verification

- <code>npm run build</code> passes successfully
- No visual or behavioral changes; purely dead-code removal