### PR TITLE
refactor: extract duplicate styled components to shared module

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 
 import { media } from "../utils";
+import { Card, SignUpButton, ImageWrapper, LeftColumn, RightColumn, RightColumnInner } from "./shared";
 
 const CommunityModule = styled.div`
   display: flex;
@@ -82,93 +83,9 @@ const CommunityInner = styled.div`
   `}
 `;
 
-const CommunityLeft = styled.div`
-  padding-bottom: 60px;
-
-  ${media.largeTablet`
-    flex: 1;
-    padding-bottom: 0;
-    padding-right: 10px;
-  `}
-`;
-
-const CommunityRight = styled.div`
-  ${media.largeTablet`
-    flex: 1;
-  `}
-`;
-
-const CommunityRightInner = styled.div`
-  ${media.largeTablet`
-    padding-left: 100px;
-  `}
-`;
-
-const CommunityCard = styled.div`
-  margin: 20px auto 20px auto;
-  display: flex;
-  padding: 16px;
-  min-height: 100px;
-  border-radius: 6px;
-  align-items: center;
-  flex-direction: column;
-  background-color: #fff;
-  justify-content: center;
-  box-shadow: 0px 30px 60px rgb(0 0 0 / 12%);
-
-  ${media.tablet`
-    width: 425px;
-    height: 42px;
-    margin: 20px 0;
-    min-height: auto;
-    flex-direction: row;
-    justify-content: space-between;
-  `}
-`;
-
-const CommunitySignUpButton = styled.a`
-  color: #fff;
-  width: 140px;
-  height: 2.81rem;
-  cursor: pointer;
-  min-width: 220px;
-  padding: 0 0.5rem;
-  text-align: center;
-  border-radius: 7px;
-  margin: 15px 0 0 0;
-  line-height: 2.8rem;
-  text-decoration: none;
-  background-color: #0070f3;
-  box-shadow: 0 4px 14px 0 rgb(0 118 255 / 39%);
-  opacity: ${({ isDisabled }) => (isDisabled ? "0.5" : "1")};
-
-  &:hover {
-    background: ${({ isDisabled }) =>
-      isDisabled ? "#0070f3" : "rgba(0,118,255,0.9)"};
-    box-shadow: 0 6px 20px rgb(0 118 255 / 23%);
-  }
-
-  ${media.tablet`
-    min-width: 220px;
-    margin: 0 15px 0 0;
-  `}
-`;
-
 const Image = styled.img`
   width: 130px;
   align-self: center;
-`;
-
-const ImageWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  justify-content: center;
-  flex: 1;
-
-  ${media.tablet`
-    padding-right: 15px;
-  `}
 `;
 
 const CommunityListWrapper = styled.div`
@@ -592,7 +509,7 @@ export const Community = () => (
       self-host, it's never been easier to transact Bitcoin.
     </CommunityDescription>
     <CommunityInner>
-      <CommunityLeft>
+      <LeftColumn>
         <CommunitySectionTitle>
           Transact with a Lightning Address today!
         </CommunitySectionTitle>
@@ -602,7 +519,7 @@ export const Community = () => (
           easily as you send emails.
         </CommunityDescriptionSmall>
         {WALLETS.map((wallet) => (
-          <CommunityCard key={wallet.name}>
+          <Card key={wallet.name}>
             <ImageWrapper>
               <Image
                 src={wallet.image}
@@ -610,10 +527,10 @@ export const Community = () => (
                 style={wallet.imageStyle || {}}
               />
             </ImageWrapper>
-            <CommunitySignUpButton target="_blank" rel="noopener noreferrer" href={wallet.url}>
+            <SignUpButton target="_blank" rel="noopener noreferrer" href={wallet.url}>
               {wallet.downloadText}
-            </CommunitySignUpButton>
-          </CommunityCard>
+            </SignUpButton>
+          </Card>
         ))}
         <CTAWrapper>
           <CTASecondary
@@ -624,9 +541,9 @@ export const Community = () => (
             View list of supported Wallets
           </CTASecondary>
         </CTAWrapper>
-      </CommunityLeft>
-      <CommunityRight>
-        <CommunityRightInner>
+      </LeftColumn>
+      <RightColumn>
+        <RightColumnInner>
           <CommunitySectionTitle>
             Want a different domain for your Lightning Address?
           </CommunitySectionTitle>
@@ -658,8 +575,8 @@ export const Community = () => (
               </VerticalLinkWrapper>
             ))}
           </CommunityVerticalListWrapper>
-        </CommunityRightInner>
-      </CommunityRight>
+        </RightColumnInner>
+      </RightColumn>
     </CommunityInner>
   </CommunityModule>
 );

--- a/components/providers.js
+++ b/components/providers.js
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 
 import { media } from "../utils";
+import { Card, SignUpButton, ImageWrapper, LeftColumn, RightColumn, RightColumnInner } from "./shared";
 
 const ProvidersModule = styled.div`
   display: flex;
@@ -26,28 +27,6 @@ const ProvidersInner = styled.div`
   ${media.largeTablet`
     max-width: 1000px;
     flex-direction: row;
-  `}
-`;
-
-const ProvidersLeft = styled.div`
-  padding-bottom: 60px;
-
-  ${media.largeTablet`
-    flex: 1;
-    padding-bottom: 0;
-    padding-right: 10px;
-  `}
-`;
-
-const ProvidersRight = styled.div`
-  ${media.largeTablet`
-    flex: 1;
-  `}
-`;
-
-const ProvidersRightInner = styled.div`
-  ${media.largeTablet`
-    padding-left: 100px;
   `}
 `;
 
@@ -142,68 +121,6 @@ const ProvidersEmailButtonText = styled.div`
   ${media.tablet`
     padding-top: 0;
     padding-left: 0;
-  `}
-`;
-
-const ProviderCard = styled.div`
-  margin: 20px auto 20px auto;
-  display: flex;
-  padding: 16px;
-  min-height: 100px;
-  border-radius: 6px;
-  align-items: center;
-  flex-direction: column;
-  background-color: #fff;
-  justify-content: center;
-  box-shadow: 0px 30px 60px rgb(0 0 0 / 12%);
-
-  ${media.tablet`
-    width: 425px;
-    height: 42px;
-    margin: 20px 0;
-    min-height: auto;
-    flex-direction: row;
-    justify-content: space-between;
-  `}
-`;
-
-const ProviderSignUpButton = styled.a`
-  color: #fff;
-  width: 140px;
-  height: 2.81rem;
-  cursor: pointer;
-  min-width: 220px;
-  padding: 0 0.5rem;
-  text-align: center;
-  border-radius: 7px;
-  margin: 15px 0 0 0;
-  line-height: 2.8rem;
-  text-decoration: none;
-  background-color: #0070f3;
-  box-shadow: 0 4px 14px 0 rgb(0 118 255 / 39%);
-  opacity: ${({ isDisabled }) => (isDisabled ? "0.5" : "1")};
-
-  &:hover {
-    background: ${({ isDisabled }) =>
-      isDisabled ? "#0070f3" : "rgba(0,118,255,0.9)"};
-    box-shadow: 0 6px 20px rgb(0 118 255 / 23%);
-  }
-
-  ${media.tablet`
-    min-width: 220px;
-    margin: 0 15px 0 0;
-  `}
-`;
-
-const ImageWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  justify-content: center;
-  flex: 1;
-
-  ${media.tablet`
-    padding-right: 15px;
   `}
 `;
 
@@ -441,14 +358,14 @@ const PROVIDERS = [
 export const Providers = () => (
   <ProvidersModule id="providers">
     <ProvidersInner>
-      <ProvidersLeft>
+      <LeftColumn>
         <ProvidersTitle>Get a Lightning Address now!</ProvidersTitle>
         <ProvidersDescription>
           Get your own Lightning Address now by using one of the apps and
           services that already support it. You’ll be set up in seconds!
         </ProvidersDescription>
         {PROVIDERS.map((provider) => (
-          <ProviderCard key={provider.name}>
+          <Card key={provider.name}>
             <ImageWrapper>
               <img
                 src={provider.image}
@@ -457,19 +374,19 @@ export const Providers = () => (
               />
               <DomainURL>you@{provider.lightningAddressDomain}</DomainURL>
             </ImageWrapper>
-            <ProviderSignUpButton
+            <SignUpButton
               isDisabled={provider.comingSoon || false}
               target="_blank"
               rel="noopener noreferrer"
               href={provider.url}
             >
               {provider.buttonText || `Open ${provider.name}`}
-            </ProviderSignUpButton>
-          </ProviderCard>
+            </SignUpButton>
+          </Card>
         ))}
-      </ProvidersLeft>
-      <ProvidersRight>
-        <ProvidersRightInner>
+      </LeftColumn>
+      <RightColumn>
+        <RightColumnInner>
           <ProvidersTitle>
             Your app doesn't support Lightning Addresses yet?
           </ProvidersTitle>
@@ -492,8 +409,8 @@ export const Providers = () => (
             <ProvidersEmailButtonImage src={"/images/email.svg"} alt="Email" />
             <ProvidersEmailButtonText>Send Email</ProvidersEmailButtonText>
           </ProvidersEmailButton>
-        </ProvidersRightInner>
-      </ProvidersRight>
+        </RightColumnInner>
+      </RightColumn>
     </ProvidersInner>
   </ProvidersModule>
 );

--- a/components/shared.js
+++ b/components/shared.js
@@ -1,0 +1,86 @@
+import styled from "styled-components";
+import { media } from "../utils";
+
+export const Card = styled.div`
+  margin: 20px auto 20px auto;
+  display: flex;
+  padding: 16px;
+  min-height: 100px;
+  border-radius: 6px;
+  align-items: center;
+  flex-direction: column;
+  background-color: #fff;
+  justify-content: center;
+  box-shadow: 0px 30px 60px rgb(0 0 0 / 12%);
+
+  ${media.tablet`
+    width: 425px;
+    height: 42px;
+    margin: 20px 0;
+    min-height: auto;
+    flex-direction: row;
+    justify-content: space-between;
+  `}
+`;
+
+export const SignUpButton = styled.a`
+  color: #fff;
+  width: 140px;
+  height: 2.81rem;
+  cursor: pointer;
+  min-width: 220px;
+  padding: 0 0.5rem;
+  text-align: center;
+  border-radius: 7px;
+  margin: 15px 0 0 0;
+  line-height: 2.8rem;
+  text-decoration: none;
+  background-color: #0070f3;
+  box-shadow: 0 4px 14px 0 rgb(0 118 255 / 39%);
+  opacity: ${({ isDisabled }) => (isDisabled ? "0.5" : "1")};
+
+  &:hover {
+    background: ${({ isDisabled }) =>
+      isDisabled ? "#0070f3" : "rgba(0,118,255,0.9)"};
+    box-shadow: 0 6px 20px rgb(0 118 255 / 23%);
+  }
+
+  ${media.tablet`
+    min-width: 220px;
+    margin: 0 15px 0 0;
+  `}
+`;
+
+export const ImageWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  flex: 1;
+
+  ${media.tablet`
+    padding-right: 15px;
+  `}
+`;
+
+export const LeftColumn = styled.div`
+  padding-bottom: 60px;
+
+  ${media.largeTablet`
+    flex: 1;
+    padding-bottom: 0;
+    padding-right: 10px;
+  `}
+`;
+
+export const RightColumn = styled.div`
+  ${media.largeTablet`
+    flex: 1;
+  `}
+`;
+
+export const RightColumnInner = styled.div`
+  ${media.largeTablet`
+    padding-left: 100px;
+  `}
+`;


### PR DESCRIPTION
## Summary

Both <code>components/community.js</code> and <code>components/providers.js</code> contained six identical styled component definitions: <code>Card</code> (formerly <code>CommunityCard</code> / <code>ProviderCard</code>), <code>SignUpButton</code> (formerly <code>CommunitySignUpButton</code> / <code>ProviderSignUpButton</code>), <code>ImageWrapper</code>, <code>LeftColumn</code> (formerly <code>CommunityLeft</code> / <code>ProvidersLeft</code>), <code>RightColumn</code> (formerly <code>CommunityRight</code> / <code>ProvidersRight</code>), and <code>RightColumnInner</code> (formerly <code>CommunityRightInner</code> / <code>ProvidersRightInner</code>). This extracts them to a new <code>components/shared.js</code> module.

## Changes

- Create <code>components/shared.js</code> with the six extracted styled components
- Import shared components in <code>community.js</code> and <code>providers.js</code>
- Remove local duplicate definitions from both files

## Verification

- <code>npm run build</code> passes successfully
- No visual or behavioral changes; purely structural deduplication
- Net diff: <code>-188</code> lines, <code>+108</code> lines (new <code>shared.js</code> + imports)