### PR TITLE
Add Mixin to the list of Lightning Address supported wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ _Bitcoin Lightning wallets that support sending and receiving to **Lightning Add
 | [ZEBEDEE App](https://zbd.gg) (and [Bots](https://zbd.gg), and [Extensions](https://zbd.gg))  | ☑️        | ☑️        |
 | [Zeus](https://github.com/ZeusLN/zeus)                            | ☑️        | ----      |
 | [LaWallet](https://app.lawallet.ar)                               | ☑️        | ☑️        |
+| [Mixin](https://messenger.mixin.one/)                             | ☑️        | ☑️        |
 
 ## TLDR
 


### PR DESCRIPTION
This PR adds Mixin to the supported wallets list.

Mixin supports sending to Lightning Addresses and receiving through Lightning Address support, so this updates the documentation to reflect current wallet support.

Reference:
https://mixin.one/news/mixin-launches-bitcoin-lightning-network-support