### PR TITLE
fix(a11y): change ProvidersEmailButton from div to anchor tag

### DIFF
--- a/components/providers.js
+++ b/components/providers.js
@@ -100,7 +100,7 @@ const ProvidersDescriptionSmall = styled(ProvidersDescription)`
   `}
 `;
 
-const ProvidersEmailButton = styled.div`
+const ProvidersEmailButton = styled.a`
   width: 65%;
   display: flex;
   cursor: pointer;
@@ -112,6 +112,7 @@ const ProvidersEmailButton = styled.div`
   flex-direction: row;
   align-items: center;
   justify-content: center;
+  text-decoration: none;
   box-shadow: 0 4px 14px 0 rgb(0 0 0 / 10%);
 
   &:hover {
@@ -483,11 +484,7 @@ export const Providers = () => (
             with just a click.
           </ProvidersDescriptionSmall>
           <ProvidersEmailButton
-            onClick={() =>
-              window.open(
-                `mailto:DEVELOPER_EMAIL_HERE?subject=Have you considered support for Lightning Address?&body=Hi there, I just learned about the Lightning Address protocol and how awesome it is for sending and receiving payments over the Bitcoin Lightning Network. I was hoping you would take a look at the lightningaddress.com website and possibly implement support for it? \n\n Lightning Addresses provide a familiar user experience with sending Lightning payments to other people online, similar to sending an email. No more QR codes or invoices / addresses. "Just pay me at satoshi@website.com"\n\n Cheers!`,
-              )
-            }
+            href={`mailto:DEVELOPER_EMAIL_HERE?subject=Have you considered support for Lightning Address?&body=Hi there, I just learned about the Lightning Address protocol and how awesome it is for sending and receiving payments over the Bitcoin Lightning Network. I was hoping you would take a look at the lightningaddress.com website and possibly implement support for it? \n\n Lightning Addresses provide a familiar user experience with sending Lightning payments to other people online, similar to sending an email. No more QR codes or invoices / addresses. "Just pay me at satoshi@website.com"\n\n Cheers!`}
           >
             <ProvidersEmailButtonImage src={"/images/email.svg"} alt="Email" />
             <ProvidersEmailButtonText>Send Email</ProvidersEmailButtonText>


### PR DESCRIPTION
## Summary

The email button in the providers section was rendered as a styled `<div>` with an `onClick` handler that opened a `mailto:` URL via `window.open()`. This pattern is not accessible:

- Not keyboard-focusable or navigable
- Missing semantic meaning for screen readers
- Does not behave like a native link

## Changes

- Change `ProvidersEmailButton` from `styled.div` to `styled.a`
- Move the `mailto:` URL from `onClick` to the native `href` prop
- Add `text-decoration: none` to preserve the existing visual appearance

This makes the element a proper HTML link, keyboard-focusable, and semantically correct without any visual change.
