### PR TITLE
fix: prevent invalid empty target/rel attributes on internal path links

### DIFF
--- a/components/paths.js
+++ b/components/paths.js
@@ -192,7 +192,7 @@ export const Paths = () => (
           <PathsCardDescription>
             {benefit.description}
           </PathsCardDescription>
-          <PathsCardButton target={benefit.isInternal ? '' : '_blank'} href={benefit.link} isSecondary={benefit.isSecondary} rel={benefit.isInternal ? '' : 'noopener noreferrer'}>
+          <PathsCardButton target={benefit.isInternal ? undefined : '_blank'} href={benefit.link} isSecondary={benefit.isSecondary} rel={benefit.isInternal ? undefined : 'noopener noreferrer'}>
             {benefit.linkText}
           </PathsCardButton>
         </PathsCard>


### PR DESCRIPTION
## Summary

The `PathsCardButton` component conditionally set `target` and `rel` based on whether a link was internal or external:

```jsx
target={benefit.isInternal ? '' : '_blank'}
rel={benefit.isInternal ? '' : 'noopener noreferrer'}
```

For internal links this rendered invalid empty attributes like `target=""` and `rel=""` in the DOM.

## Changes

- Use `undefined` instead of `''` when the attribute is not needed
- React then omits the attribute entirely, producing clean HTML
