### PR TITLE
fix: update NiceHash Lightning Address domain

### DIFF
--- a/components/providers.js
+++ b/components/providers.js
@@ -391,7 +391,7 @@ const PROVIDERS = [
     imageStyle: {
       width: "125px",
     },
-    lightningAddressDomain: "nicehash.com",
+    lightningAddressDomain: "ln.nicehash.com",
     url: "https://nicehash.com",
   },
   {


### PR DESCRIPTION
## Summary
- update the NiceHash provider card to show the current Lightning Address domain: `ln.nicehash.com`

## Testing
- not run; single copy/data update

Closes #152