### PR TITLE
chore: patch postcss XSS vulnerability via npm override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -815,9 +815,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -901,9 +901,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -920,9 +920,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -1107,34 +1107,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/styled-components/node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
     "react-qr-code": "^2.0.15",
     "styled-components": "^6.1.0"
   },
+  "overrides": {
+    "postcss": "^8.5.10"
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary

Patches [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) — a moderate severity XSS vulnerability in PostCSS <8.5.10 that allows unescaped `</style>` in CSS stringify output.

## Problem

- `npm audit` reported 3 moderate severity vulnerabilities
- `next@16.2.6` depends on `postcss@8.4.31`, which is affected
- `styled-components@6.4.2` also depends on a vulnerable `postcss` range
- No newer stable `next` version is available that patches this

## Solution

- Add `npm overrides` to force `postcss@^8.5.10` across all transitive dependencies
- `npm install` resolves `postcss@8.5.15` (latest patch in 8.x line)
- `npm audit` now shows **0 vulnerabilities**
- `npm run build` passes successfully — no breaking changes

## Verification

```
$ npm audit --production
found 0 vulnerabilities

$ npm run build
▲ Next.js 16.2.6 (Turbopack)
✓ Compiled successfully
✓ Generating static pages
```

## Risk Assessment

PostCSS is a build-time dependency in this Next.js app. The CSS is generated from trusted styled-components code at build time. The XSS risk was low, but patching the dependency is the correct security hygiene.
