### PR TITLE
fix: avoid rendering empty target and rel attributes on internal links

### DIFF
--- a/components/paths.js
+++ b/components/paths.js
@@ -192,7 +192,7 @@ export const Paths = () => (
           <PathsCardDescription>
             {benefit.description}
           </PathsCardDescription>
-          <PathsCardButton target={benefit.isInternal ? '' : '_blank'} href={benefit.link} isSecondary={benefit.isSecondary} rel={benefit.isInternal ? '' : 'noopener noreferrer'}>
+          <PathsCardButton target={benefit.isInternal ? undefined : '_blank'} href={benefit.link} isSecondary={benefit.isSecondary} rel={benefit.isInternal ? undefined : 'noopener noreferrer'}>
             {benefit.linkText}
           </PathsCardButton>
         </PathsCard>


### PR DESCRIPTION
## Summary
When \"isInternal\" is true on the PathsCardButton, the component was rendering \"target=\"\"\" and \"rel=\"\"\" in the HTML. These empty attributes are invalid and should be omitted entirely.

## Fix
Use \"undefined\" instead of an empty string for the \"target\" and \"rel\" props when \"isInternal\" is true. React will skip rendering props with undefined values.

## Verification
- No visual or functional change to external links
- Internal links no longer carry empty target/rel attributes
- Build passes successfully