### PR TITLE
docs: add NiceHash to README wallet list

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ _Bitcoin Lightning wallets that support sending and receiving to **Lightning Add
 | [Mash](https://getmash.com/)                                      | ----      | ☑️        |
 | [Muun](https://muun.com/)                                         | ----      | ----      |
 | [NOAH](https://app.noah.com/)                                     | ☑️        | ☑️        |
+| [NiceHash](https://nicehash.com/)                                 | ----      | ☑️        |
 | [Numeraire](https://numeraire.tech/)                              | ☑️         | ☑️         |
 | [Oak Node](https://oak-node.net)                                  | ☑️        | ----      |
 | [Phoenix](https://phoenix.acinq.co/)                              | ☑️        | ----      |


### PR DESCRIPTION
## Summary

NiceHash is an active Lightning Address provider (domain: `ln.nicehash.com`) already listed on the website. Adding it to the canonical README wallet table for completeness and consistency with the providers section.

### Changes
- Added NiceHash to the "Wallets Supported" table in README.md
- Classified as receiving-only (consistent with other providers like Mash, Bookmark.org, Stacker News)

### References
- Commit de454e7 updated the NiceHash Lightning Address domain
- NiceHash appears in `components/providers.js` as an active provider