### PR TITLE
refactor: avoid empty string target/rel attributes on internal links

### DIFF
--- a/components/paths.js
+++ b/components/paths.js
@@ -192,7 +192,7 @@ export const Paths = () => (
           <PathsCardDescription>
             {benefit.description}
           </PathsCardDescription>
-          <PathsCardButton target={benefit.isInternal ? '' : '_blank'} href={benefit.link} isSecondary={benefit.isSecondary} rel={benefit.isInternal ? '' : 'noopener noreferrer'}>
+          <PathsCardButton target={benefit.isInternal ? undefined : '_blank'} href={benefit.link} isSecondary={benefit.isSecondary} rel={benefit.isInternal ? undefined : 'noopener noreferrer'}>
             {benefit.linkText}
           </PathsCardButton>
         </PathsCard>


### PR DESCRIPTION
## Summary

The `PathsCardButton` component rendered `target=""` and `rel=""` for internal anchor links (e.g., `#providers`, `#community`). Using `undefined` prevents these unnecessary attributes from being added to the DOM, improving HTML cleanliness and avoiding potential accessibility or behavior edge cases.

### Changes
- Changed `target={benefit.isInternal ? '' : '_blank'}` to `target={benefit.isInternal ? undefined : '_blank'}`
- Changed `rel={benefit.isInternal ? '' : 'noopener noreferrer'}` to `rel={benefit.isInternal ? undefined : 'noopener noreferrer'}`

### Verification
- `npm run build` passes successfully
- No visual or behavioral changes