### PR TITLE
chore: remove unused react-is dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "next": "^16.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-is": "^19.0.0",
         "react-qr-code": "^2.0.15",
         "styled-components": "^6.1.0"
       }
@@ -977,12 +976,6 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
-    },
-    "node_modules/react-is": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
-      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
-      "license": "MIT"
     },
     "node_modules/react-qr-code": {
       "version": "2.0.18",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "next": "^16.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-is": "^19.0.0",
     "react-qr-code": "^2.0.15",
     "styled-components": "^6.1.0"
   },


### PR DESCRIPTION
## Summary

Removes the unused direct dependency on react-is.

- No source files import react-is directly.
- styled-components v6 does not list react-is as a dependency.
- react-qr-code already gets its own copy via prop-types as a transitive dependency.

This change does not affect the production build.