### PR TITLE
fix: add Mixin to website footer wallet lists

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -101,6 +101,10 @@ const FOOTER = [
         title: "Piggy",
       },
       {
+        link: "https://messenger.mixin.one",
+        title: "Mixin",
+      },
+      {
         link: "https://lexe.app",
         title: "Lexe",
       },
@@ -172,6 +176,10 @@ const FOOTER = [
       {
         link: "https://pig.gy",
         title: "Piggy",
+      },
+      {
+        link: "https://messenger.mixin.one",
+        title: "Mixin",
       },
       {
         link: "https://lexe.app",


### PR DESCRIPTION
## Summary

Adds Mixin to the Sending and Receiving footer wallet lists on the website.

- Mixin was added to the README in PR #161 but was not reflected in the website footer.
- This keeps the website footer in sync with the canonical README supported-wallets list.
- Note: Mixin requires a logo image to be added to the community section; this PR only addresses the footer lists.