### PR TITLE
fix: move font import from createGlobalStyle to document head link tags

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,8 +1,6 @@
 import { createGlobalStyle, ThemeProvider } from 'styled-components'
 
 const GlobalStyle = createGlobalStyle`
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@200;400;500;700;900&display=swap');
-
   body {
     margin: 0;
     padding: 0;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -31,7 +31,11 @@ export default class MyDocument extends Document {
   render() {
     return (
       <Html lang="en">
-        <Head />
+        <Head>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+          <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;400;500;700;900&display=swap" rel="stylesheet" />
+        </Head>
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
## Summary

The `@import` rule inside styled-components' `createGlobalStyle` is a well-known anti-pattern that causes:

- **FOUC (Flash of Unstyled Content)** — the font import happens after JS/CSS parsing, causing visible text reflow
- **Blocking CSS parsing** — `@import` is render-blocking and delays other CSS

## Changes

- Removed `@import url(...)` from `pages/_app.js` `createGlobalStyle`
- Added `<link>` tags in `pages/_document.js` `<Head>` for Google Fonts with `preconnect` hints

## Rationale

Next.js and styled-components documentation both recommend using `<link>` tags in the document `<head>` instead of `@import` inside `createGlobalStyle` for better performance and to avoid FOUC.

## Test Plan

- [x] Build passes cleanly
- [x] No visual regressions expected — the same font is loaded, just earlier in the document lifecycle