### PR TITLE
fix: add BitcoLi and Rizful to footer wallet lists

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -108,6 +108,14 @@ const FOOTER = [
         link: "https://lexe.app",
         title: "Lexe",
       },
+      {
+        link: "https://bitcoli.com/",
+        title: "BitcoLi",
+      },
+      {
+        link: "https://rizful.com/",
+        title: "Rizful",
+      },
     ],
   },
   {
@@ -184,6 +192,14 @@ const FOOTER = [
       {
         link: "https://lexe.app",
         title: "Lexe",
+      },
+      {
+        link: "https://bitcoli.com/",
+        title: "BitcoLi",
+      },
+      {
+        link: "https://rizful.com/",
+        title: "Rizful",
       },
     ],
   },


### PR DESCRIPTION
## Summary

The README lists both **BitcoLi** and **Rizful** as supported wallets with sending and receiving capabilities, but they were missing from the website footer. This is a documentation drift between the README and the web app.

## Changes

- Added BitcoLi to the footer Sending section
- Added Rizful to the footer Sending section
- Added BitcoLi to the footer Receiving section
- Added Rizful to the footer Receiving section

## Rationale

The README is the canonical list of supported wallets. The website footer should reflect the same wallets to ensure users visiting the site can discover all available options. Mixin was recently added to the footer in a previous PR; this completes the sync for BitcoLi and Rizful.

## Test Plan

- [x] Build passes cleanly
- [x] No visual regressions — this is just adding two link items to existing footer lists