### PR TITLE
refactor: remove dead isDisabled prop from CommunitySignUpButton

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -140,11 +140,9 @@ const CommunitySignUpButton = styled.a`
   text-decoration: none;
   background-color: #0070f3;
   box-shadow: 0 4px 14px 0 rgb(0 118 255 / 39%);
-  opacity: ${({ isDisabled }) => (isDisabled ? "0.5" : "1")};
 
   &:hover {
-    background: ${({ isDisabled }) =>
-      isDisabled ? "#0070f3" : "rgba(0,118,255,0.9)"};
+    background: rgba(0,118,255,0.9);
     box-shadow: 0 6px 20px rgb(0 118 255 / 23%);
   }
 


### PR DESCRIPTION
## Summary

The `isDisabled` prop on `CommunitySignUpButton` was never passed in any usage throughout the codebase. The conditional `opacity` and `&:hover` background styling based on `isDisabled` was dead code — `isDisabled` was always `undefined` which evaluated to falsy, so the component always rendered with `opacity: 1` and the non-disabled hover state.

## Changes

- Removed `opacity: ${({ isDisabled }) => (isDisabled ? "0.5" : "1")};` from `CommunitySignUpButton`
- Removed the conditional `&:hover` background that checked `isDisabled`
- Simplified the hover state to always use `background: rgba(0,118,255,0.9)`

## Rationale

Removing dead code reduces cognitive load and prevents confusion for future developers who might wonder where `isDisabled` is supposed to be set. The `ProviderSignUpButton` component still retains `isDisabled` since `comingSoon` is a valid feature flag for providers, but `CommunitySignUpButton` had no such use case.

## Test Plan

- [x] Build passes cleanly
- [x] No visual regressions — the component rendered with `opacity: 1` and the non-disabled hover state anyway