### PR TITLE
refactor: extract shared CTASecondary styled component

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media } from "../utils";
+import { media, CTASecondary as BaseCTASecondary } from "../utils";
 
 const CommunityModule = styled.div`
   display: flex;
@@ -268,28 +268,8 @@ const CTAWrapper = styled.div`
   `}
 `;
 
-const CTASecondary = styled.a`
-  color: #696969;
-  cursor: pointer;
-  height: 2.81rem;
-  background: #fff;
+const CTASecondary = styled(BaseCTASecondary)`
   width: 280px;
-  text-align: center;
-  padding: 0;
-  margin: 10px 0 0 0;
-  text-decoration: none;
-  line-height: 2.8rem;
-  border-radius: 7px;
-  box-shadow: 0 4px 14px 0 rgb(0 0 0 / 10%);
-
-  &:hover {
-    background: rgba(255, 255, 255, 0.9);
-    box-shadow: 0 6px 20px rgb(93 93 93 / 23%);
-  }
-
-  ${media.tablet`
-    margin: 0 0 0 15px;
-  `}
 `;
 
 const CommunityVerticalListWrapper = styled.div`

--- a/components/hero.js
+++ b/components/hero.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import styled from 'styled-components';
 
-import { media, CTAPrimary } from '../utils';
+import { media, CTAPrimary, CTASecondary } from '../utils';
 
 const Wrapper = styled.div`
   display: flex;
@@ -120,30 +120,6 @@ const CTAWrapper = styled.div`
 
   ${media.tablet`
     flex-direction: row;
-  `}
-`;
-
-const CTASecondary = styled.a`
-  color: #696969;
-  cursor: pointer;
-  height: 2.81rem;
-  background: #fff;
-  width: 260px;
-  text-align: center;
-  padding: 0;
-  margin: 10px 0 0 0;
-  text-decoration: none;
-  line-height: 2.8rem;
-  border-radius: 7px;
-  box-shadow: 0 4px 14px 0 rgb(0 0 0 / 10%);
-
-  &:hover {
-    background: rgba(255,255,255,0.9);
-    box-shadow: 0 6px 20px rgb(93 93 93 / 23%);
-  }
-
-  ${media.tablet`
-    margin: 0 0 0 15px;
   `}
 `;
 

--- a/utils.js
+++ b/utils.js
@@ -45,3 +45,27 @@ export const CTAPrimary = styled.a`
     margin: 0 15px 0 0;
   `}
 `;
+
+export const CTASecondary = styled.a`
+  color: #696969;
+  cursor: pointer;
+  height: 2.81rem;
+  background: #fff;
+  width: 260px;
+  text-align: center;
+  padding: 0;
+  margin: 10px 0 0 0;
+  text-decoration: none;
+  line-height: 2.8rem;
+  border-radius: 7px;
+  box-shadow: 0 4px 14px 0 rgb(0 0 0 / 10%);
+
+  &:hover {
+    background: rgba(255,255,255,0.9);
+    box-shadow: 0 6px 20px rgb(93 93 93 / 23%);
+  }
+
+  ${media.tablet`
+    margin: 0 0 0 15px;
+  `}
+`;


### PR DESCRIPTION
## Summary

The `CTASecondary` styled component was defined identically in both `hero.js` and `community.js` — only the `width` differed (260px vs 280px). This is the same duplication pattern that was already resolved for `CTAPrimary` in PR #176.

## Changes

- Extracted `CTASecondary` to `utils.js` with the shared base styles
- `hero.js` now imports `CTASecondary` directly from `utils.js`
- `community.js` imports `CTASecondary` and extends it with `width: 280px`
- Removed ~20 lines of duplicated CSS across the two components

## Rationale

Reducing duplicated styled-component CSS improves maintainability and follows the established pattern of sharing common UI primitives in `utils.js`. Future style changes to the secondary CTA button only need to be made in one place.

## Test Plan

- [x] Build passes cleanly
- [x] No visual regressions — the same styles are applied, just from a shared source