### PR TITLE
chore: remove stray semicolon in PathsCardButton CSS

### DIFF
--- a/components/paths.js
+++ b/components/paths.js
@@ -121,7 +121,6 @@ const PathsCardButton = styled.a`
   color: ${({ isSecondary }) => isSecondary ? '#696969' : '#fff' };
   background-color: ${({ isSecondary }) => isSecondary ? '#fff' : '#0070f3' };
   box-shadow: ${({ isSecondary }) => isSecondary ? '0 4px 14px 0 rgb(0 0 0 / 10%)' : '0 4px 14px 0 rgb(0 118 255 / 39%)' };
-  ;
 
   &:hover {
     background-color: ${({ isSecondary }) => isSecondary ? 'rgba(255,255,255,0.9)' : 'rgba(0,118,255,0.9)' };


### PR DESCRIPTION
## Summary

The  styled component had a stray semicolon on its own line after the  declaration. This is a CSS template literal typo that doesn't cause runtime errors (styled-components handles it gracefully) but is sloppy code that could confuse future maintainers.

## Changes

- Removed the stray  on line 124 of 

## Rationale

Clean, typo-free CSS improves maintainability and prevents confusion. The stray semicolon was a clear copy-paste or editing artifact.

## Test Plan

- [x] Build passes cleanly
- [x] No visual regressions — the stray semicolon had no effect on rendered styles