### PR TITLE
refactor: remove redundant || false in ProviderSignUpButton isDisabled

### DIFF
--- a/components/providers.js
+++ b/components/providers.js
@@ -466,7 +466,7 @@ export const Providers = () => (
               <DomainURL>you@{provider.lightningAddressDomain}</DomainURL>
             </ImageWrapper>
             <ProviderSignUpButton
-              isDisabled={provider.comingSoon || false}
+              isDisabled={provider.comingSoon}
               target="_blank"
               rel="noopener noreferrer"
               href={provider.url}


### PR DESCRIPTION
## Summary

The `ProviderSignUpButton` component received `isDisabled={provider.comingSoon || false}`. The `|| false` suffix was redundant: `provider.comingSoon` is either `true`, `false`, or `undefined` (for providers without the property). In all three cases, `provider.comingSoon || false` produces the exact same result as `provider.comingSoon` because:

- `true || false` → `true`
- `false || false` → `false`
- `undefined || false` → `false`

The `isDisabled` prop is consumed in a styled-component ternary where `undefined` is already treated as falsy, so the `|| false` guard added no value.

## Changes

- Changed `isDisabled={provider.comingSoon || false}` to `isDisabled={provider.comingSoon}`

## Rationale

Removing redundant boolean normalization keeps the code cleaner and easier to read. The `comingSoon` property is an explicit boolean flag, so its value directly maps to the disabled state without any coercion needed.

## Test Plan

- [x] Build passes cleanly
- [x] No visual regressions — all providers without `comingSoon` render as enabled, `comingSoon: false` renders as enabled, `comingSoon: true` renders as disabled (same behavior as before)
