### PR TITLE
fix: add missing wallets to footer.js

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -108,6 +108,22 @@ const FOOTER = [
         link: "https://lexe.app",
         title: "Lexe",
       },
+      {
+        link: "https://www.walletofsatoshi.com/",
+        title: "Wallet of Satoshi",
+      },
+      {
+        link: "https://bitcoli.com/",
+        title: "BitcoLi wallet",
+      },
+      {
+        link: "https://rizful.com/",
+        title: "Rizful",
+      },
+      {
+        link: "https://coinkit.de/",
+        title: "CoinKit",
+      },
     ],
   },
   {
@@ -184,6 +200,22 @@ const FOOTER = [
       {
         link: "https://lexe.app",
         title: "Lexe",
+      },
+      {
+        link: "https://www.walletofsatoshi.com/",
+        title: "Wallet of Satoshi",
+      },
+      {
+        link: "https://bitcoli.com/",
+        title: "BitcoLi wallet",
+      },
+      {
+        link: "https://rizful.com/",
+        title: "Rizful",
+      },
+      {
+        link: "https://coinkit.de/",
+        title: "CoinKit",
       },
     ],
   },


### PR DESCRIPTION
## Summary

Wallet of Satoshi, BitcoLi wallet, Rizful, and CoinKit are listed in the README with sending and receiving support, but were not present in the footer.js wallet directory. This adds them to both the Sending and Receiving sections for consistency with the rest of the site.