### PR TITLE
fix(a11y): add aria-label to QR code donation link

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -302,7 +302,7 @@ export const Footer = () => (
       <Bottom>
         <BottomInner>
           <BottomQR>
-            <a href={`lightning:${DONATION_QR_CODE}`}>
+            <a href={`lightning:${DONATION_QR_CODE}`} aria-label="Donate via Lightning">
               <QRCode size={100} value={DONATION_QR_CODE} />
             </a>
           </BottomQR>


### PR DESCRIPTION
## Summary

The QR code donation link in the footer had no accessible text, making it unusable for screen reader users. Adding an aria-label provides context for what the link does.