### PR TITLE
fix: add missing viewport and description meta tags

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -20,6 +20,11 @@ export default function Home() {
         <title>
           The Lightning Address - Send and receive Bitcoin like you do emails
         </title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="description"
+          content="Like an email address, but for your Bitcoin. An Internet Identifier that allows anyone to send you Bitcoin instantly over the Lightning Network. No scanning QR codes or pasting invoices."
+        />
         <link
           rel="icon"
           type="image/png"


### PR DESCRIPTION
## Summary

The page `<head>` was missing two critical meta tags:
- `<meta name="viewport" content="width=device-width, initial-scale=1" />` — required for responsive rendering on mobile devices
- `<meta name="description" ... />` — required for SEO search result snippets

## Changes

- Added `viewport` meta tag to `pages/index.js`
- Added `description` meta tag using the existing `og:description` content for consistency

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No visual or behavioral changes
