### PR TITLE
refactor: remove dead || [] fallback guards

### DIFF
--- a/components/benefits.js
+++ b/components/benefits.js
@@ -181,7 +181,7 @@ export const Benefits = () => (
     <BenefitsTitle>Why do I need a Lightning Address?</BenefitsTitle>
     <BenefitsDescription>We created the Lightning Address protocol to empower everyone to send money like we send emails — instantly and abundantly. Coupled with the Lightning Network’s ability to send Bitcoin instantly and with (almost) no fees, we’re ushering in a new standard for how value moves around the world.</BenefitsDescription>
     <BenefitsCardGrid>
-      {(BENEFITS || []).map((benefit) => (
+      {BENEFITS.map((benefit) => (
         <BenefitsCard key={benefit.title}>
           <BenefitsCardImage src={benefit.image} alt={benefit.title} />
           <BenefitsCardTitle>

--- a/components/footer.js
+++ b/components/footer.js
@@ -304,10 +304,10 @@ export const Footer = () => (
   <Wrapper>
     <InnerWrapper>
       <Menus>
-        {(FOOTER || []).map((col) => (
+        {FOOTER.map((col) => (
           <Column key={col.title}>
             <ColumnTitle>{col.title}</ColumnTitle>
-            {(col.items || []).map((item) => (
+            {col.items.map((item) => (
               <ColumnItem key={item.link} href={item.link} target="_blank" rel="noopener noreferrer">
                 {item.title}
               </ColumnItem>


### PR DESCRIPTION
## Summary

The `BENEFITS` and `FOOTER` arrays are constants defined in the same file as their usage, so the `|| []` fallback guards are dead code that can never trigger. Removing them improves readability and avoids unnecessary defensive patterns.

## Changes

- `components/benefits.js`: remove `|| []` from `BENEFITS.map()`
- `components/footer.js`: remove `|| []` from `FOOTER.map()` and `col.items.map()`

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes