### PR TITLE
fix: add missing wallets to footer.js

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -116,6 +116,30 @@ const FOOTER = [
         link: "https://rizful.com/",
         title: "Rizful",
       },
+      {
+        link: "https://app.noah.com",
+        title: "NOAH",
+      },
+      {
+        link: "https://bitnob.com",
+        title: "Bitnob",
+      },
+      {
+        link: "https://btcpayserver.org/",
+        title: "BTCPay Server",
+      },
+      {
+        link: "https://coinos.io",
+        title: "coinos",
+      },
+      {
+        link: "https://electrum.org/",
+        title: "Electrum",
+      },
+      {
+        link: "https://blixtwallet.github.io/",
+        title: "Blixt",
+      },
     ],
   },
   {
@@ -200,6 +224,22 @@ const FOOTER = [
       {
         link: "https://rizful.com/",
         title: "Rizful",
+      },
+      {
+        link: "https://app.noah.com",
+        title: "NOAH",
+      },
+      {
+        link: "https://bitnob.com",
+        title: "Bitnob",
+      },
+      {
+        link: "https://btcpayserver.org/",
+        title: "BTCPay Server",
+      },
+      {
+        link: "https://electrum.org/",
+        title: "Electrum",
       },
     ],
   },


### PR DESCRIPTION
## Summary

Several wallets listed in the README with sending and/or receiving support were absent from the footer.js wallet directory. This adds them to the appropriate sections for consistency with the rest of the site.

## Wallets Added

| Wallet | Sending | Receiving | Notes |
|--------|---------|-----------|-------|
| NOAH | ☑️ | ☑️ | Already in providers section |
| Bitnob | ☑️ | ☑️ | Already in providers section |
| BTCPay Server | ☑️ | ☑️ | Already in providers section |
| coinos | ☑️ | — | Already in Receiving section |
| Electrum | ☑️ | ☑️ | Already in community section |
| Blixt | ☑️ | — | Already in community section; receiving is WIP per README |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No visual or behavioral changes beyond the added footer links