### PR TITLE
fix(docs): update outdated repository links

### DIFF
--- a/BRIDGE.md
+++ b/BRIDGE.md
@@ -6,7 +6,7 @@ At its core, a Lightning Address Bridge Server is a simple HTTP server that has 
 
 ## `bridgeaddr`
 
-The [`bridgeaddr`](https://bridgeaddr.fiatjaf.com/) server tool is a simple server that allows you to receive Lightning payments at `yourname@yourdomain.com` in a non-custodial fashion. It is compatible with the following Lightning backends:
+The [`bridgeaddr`](https://github.com/fiatjaf/bridgeaddr) server tool is a simple server that allows you to receive Lightning payments at `yourname@yourdomain.com` in a non-custodial fashion. It is compatible with the following Lightning backends:
 
 * Sparko
 * LND
@@ -15,13 +15,13 @@ The [`bridgeaddr`](https://bridgeaddr.fiatjaf.com/) server tool is a simple serv
 
 This server will serve the necessary JSON and then use RPC calls to connect to your node and fetch invoices on demand. You don't have to do anything besides buying a domain and setting up some DNS records. HTTPS will be provided automatically for you.
 
-If you already have a domain name and a Lightning node and are ready to get started, head on over to the [`bridgeaddr`](https://bridgeaddr.fiatjaf.com/) documentation page to set it up. You can also run `bridgeaddr` server yourself by going to the [GitHub repository](https://github.com/fiatjaf/bridgeaddr).
+If you already have a domain name and a Lightning node and are ready to get started, head on over to the [`bridgeaddr`](https://github.com/fiatjaf/bridgeaddr) documentation page to set it up. You can also run `bridgeaddr` server yourself by going to the [GitHub repository](https://github.com/fiatjaf/bridgeaddr).
 
 ## Satdress
 
 ![](https://user-images.githubusercontent.com/2574011/129462071-49797997-f39a-4e8f-a378-5c9a9818adca.png)
 
-If you'd like to host a Bridge Server on your own infrastructure to allow for you (and anyone else you would like to give access to) to connect your Lightning Address to a Lightning node, you can use [Satdress](https://github.com/fiatjaf/satdress). Satdress is a federated lightning addresses server.
+If you'd like to host a Bridge Server on your own infrastructure to allow for you (and anyone else you would like to give access to) to connect your Lightning Address to a Lightning node, you can use [Satdress](https://github.com/nbd-wtf/satdress). Satdress is a federated lightning addresses server.
 
 Similar to `bridgeaddr` you can simply enter a few parameters on DNS and quickly connect your non-custodial Lightning node to a Lightning Address. It's a Simple plug-n-play server for supporting [Lightning Address](https://lightningaddress.com) protocol.
 

--- a/DIY.md
+++ b/DIY.md
@@ -24,9 +24,9 @@ Requirement: HTTPS is expected to be used, since this is sensitive data, where M
 In order to support receiving to a Lightning Address on your own infrastructure/domain setup, you will need a  handful of things outlined below.
 
 * HTTP Server
-  * [LNURL Pay support](https://github.com/fiatjaf/lnurl-rfc/blob/master/lnurl-pay.md)
-    * [Internet Identifier metadata support](https://github.com/fiatjaf/lnurl-rfc/blob/luds/16.md)
-    * [Commenting support](https://github.com/fiatjaf/lnurl-rfc/blob/luds/12.md) (Optional)
+  * [LNURL Pay support](https://github.com/lnurl/luds/blob/master/lnurl-pay.md)
+    * [Internet Identifier metadata support](https://github.com/lnurl/luds/blob/luds/16.md)
+    * [Commenting support](https://github.com/lnurl/luds/blob/luds/12.md) (Optional)
   * HTTPS security
 * Lightning Network node
   * Used to create BOLT11 invoices for LNURL Pay flow
@@ -36,16 +36,16 @@ You will essentially need a RESTful HTTP API server that will handle GET request
 
 #### Internet Identifier
 
-The Lightning Address is nothing more than another [Internet Identifier](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1), it should look identical to an email address. For more details on how to set up the Internet Identifier metadata check [here](https://github.com/fiatjaf/lnurl-rfc/blob/luds/16.md).
+The Lightning Address is nothing more than another [Internet Identifier](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1), it should look identical to an email address. For more details on how to set up the Internet Identifier metadata check [here](https://github.com/lnurl/luds/blob/luds/16.md).
 
 #### Comments
 
-In order to accept messages/comments alongside payments to your Lightning Address, you will have to support the optional `comment` feature outlined [here](https://github.com/fiatjaf/lnurl-rfc/blob/luds/12.md).
+In order to accept messages/comments alongside payments to your Lightning Address, you will have to support the optional `comment` feature outlined [here](https://github.com/lnurl/luds/blob/luds/12.md).
 
 ## LNURL Protocol
 
-[LNURL](https://github.com/fiatjaf/lnurl-rfc) is a UX protocol built for the Lightning Network that aims to facilitate the sending, receiving, and handling of Lightning invoices from wallets to services (and vice versa).
+[LNURL](https://github.com/lnurl/luds) is a UX protocol built for the Lightning Network that aims to facilitate the sending, receiving, and handling of Lightning invoices from wallets to services (and vice versa).
 
-[LNURL](https://github.com/fiatjaf/lnurl-rfc) is comprised of many sub-protocols, each with their own required, and optional, properties and features. Please refer to the [LNURL RFC documentation](https://github.com/fiatjaf/lnurl-rfc) for more details on how LNURL works. Specifically for the Lightning Address protocol, we are relying on the Internet Identifier metadata optional feature of the LNURL Pay sub-protocol.
+[LNURL](https://github.com/lnurl/luds) is comprised of many sub-protocols, each with their own required, and optional, properties and features. Please refer to the [LNURL RFC documentation](https://github.com/lnurl/luds) for more details on how LNURL works. Specifically for the Lightning Address protocol, we are relying on the Internet Identifier metadata optional feature of the LNURL Pay sub-protocol.
 
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ _Bitcoin Lightning wallets that support sending and receiving to **Lightning Add
 
 ## TLDR
 
-Here's a quick primer on how Lightning Address works and how it relies on the [LNURL Pay protocol](https://github.com/fiatjaf/lnurl-rfc/blob/master/lnurl-pay.md).
+Here's a quick primer on how Lightning Address works and how it relies on the [LNURL Pay protocol](https://github.com/lnurl/luds/blob/master/lnurl-pay.md).
 
 ![](https://i.imgur.com/DIV5q8q.png)
 
@@ -87,7 +87,7 @@ All illustrative and informative diagrams are available under the [DIAGRAMS](./d
 
 ## Contributions
 
-Contributions are welcome, for both the lightningaddress.com website as well as the Lightning Address protocol itself. Please submit a PR here or on the core [LNURL RFC repository](https://github.com/fiatjaf/lnurl-rfc).
+Contributions are welcome, for both the lightningaddress.com website as well as the Lightning Address protocol itself. Please submit a PR here or on the core [LNURL RFC repository](https://github.com/lnurl/luds).
 
 ## Donations
 

--- a/components/community.js
+++ b/components/community.js
@@ -347,13 +347,13 @@ const SATDRESS_SERVERS = [
 
 const BRIDGE_SERVERS = [
   {
-    urlLink: "https://github.com/fiatjaf/satdress/",
+    urlLink: "https://github.com/nbd-wtf/satdress/",
     urlText: "Satdress",
     description:
       "Federated Lightning Address server anyone can self-host to receive Lightning payments at you@yourdomain.com noncustodially.",
   },
   {
-    urlLink: "https://bridgeaddr.fiatjaf.com/",
+    urlLink: "https://github.com/fiatjaf/bridgeaddr",
     urlText: "BridgeAddr",
     description:
       "Bridge Server that allows setting domain DNS configuration and receive payments at you@yourdomain.com noncustodially.",

--- a/components/footer.js
+++ b/components/footer.js
@@ -28,7 +28,7 @@ const FOOTER = [
         title: "Internet Identifier RFC",
       },
       {
-        link: "https://github.com/fiatjaf/lnurl-rfc",
+        link: "https://github.com/lnurl/luds",
         title: "LNURL RFC",
       },
     ],
@@ -134,7 +134,7 @@ const FOOTER = [
         title: "Spark Wallet",
       },
       {
-        link: "https://github.com/fiatjaf/satdress",
+        link: "https://github.com/nbd-wtf/satdress",
         title: "Satdress",
       },
       {


### PR DESCRIPTION
## Summary

Several repository and website links across the codebase were outdated, returning redirects or DNS errors. This updates them to the correct current URLs.

## Changes

| Old URL | New URL | Status |
|---------|---------|--------|
|  |  | 301 redirect |
|  |  | 301 redirect |
|  |  | DNS error (down) |

## Files Updated

-  — all 6  references
-  — 2  references
-  —  repo +  website links
-  —  and  footer links
-  —  and  community links

## Test Plan

- [x] Verified all new URLs return 200 OK
- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes