### PR TITLE
refactor: remove dead padding and redundant line-height from hero Description

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -76,11 +76,9 @@ const Description = styled.p`
   margin: 20px auto 0 auto;
 
   ${media.tablet`
-    padding: 0;
     font-size: 20px;
     padding: 0 30px;
     max-width: 500px;
-    line-height: 1.4;
     letter-spacing: -1px;
   `}
 `;


### PR DESCRIPTION
## Summary

Two focused cleanup fixes in `components/hero.js` for the `Description` styled component's tablet media query:

1. **Remove dead `padding: 0`** — In the `${media.tablet` block, `padding: 0` is immediately overridden by `padding: 0 30px` on the very next line. The first declaration is dead code that never takes effect.

2. **Remove redundant `line-height: 1.4`** — The base `Description` styles already declare `line-height: 1.4`. Since this is a unitless ratio, it scales correctly with the `font-size: 20px` override in the tablet query. Re-declaring it is unnecessary.

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes
