### PR TITLE
refactor: remove redundant transition from BenefitsCard hover

### DIFF
--- a/components/benefits.js
+++ b/components/benefits.js
@@ -90,7 +90,6 @@ const BenefitsCard = styled.div`
 
   &:hover {
     border: 1px solid #ccc;
-    transition: box-shadow .2s ease;
     box-shadow: 0 8px 30px rgba(0,0,0,0.12);
   }
 `;


### PR DESCRIPTION
## Summary

The base `BenefitsCard` styles already declare `transition: box-shadow .2s ease`, so repeating it in the `&:hover` block is unnecessary. This matches the cleanup already done for `PathsCard` in PR #194.

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes