### PR TITLE
refactor: use transient prop $isDisabled in ProviderSignUpButton

### DIFF
--- a/components/providers.js
+++ b/components/providers.js
@@ -182,11 +182,11 @@ const ProviderSignUpButton = styled.a`
   text-decoration: none;
   background-color: #0070f3;
   box-shadow: 0 4px 14px 0 rgb(0 118 255 / 39%);
-  opacity: ${({ isDisabled }) => (isDisabled ? "0.5" : "1")};
+  opacity: ${({ $isDisabled }) => ($isDisabled ? "0.5" : "1")};
 
   &:hover {
-    background: ${({ isDisabled }) =>
-      isDisabled ? "#0070f3" : "rgba(0,118,255,0.9)"};
+    background: ${({ $isDisabled }) =>
+      $isDisabled ? "#0070f3" : "rgba(0,118,255,0.9)"};
     box-shadow: 0 6px 20px rgb(0 118 255 / 23%);
   }
 
@@ -467,7 +467,7 @@ export const Providers = () => (
               <DomainURL>you@{provider.lightningAddressDomain}</DomainURL>
             </ImageWrapper>
             <ProviderSignUpButton
-              isDisabled={provider.comingSoon}
+              $isDisabled={provider.comingSoon}
               target="_blank"
               rel="noopener noreferrer"
               href={provider.url}


### PR DESCRIPTION
## Summary

`styled-components` v6 forwards non-standard props to the underlying DOM element. The `isDisabled` prop on `ProviderSignUpButton` (a styled `<a>`) was being rendered as `isdisabled="false"` in the HTML.

Renaming to the transient prop `$isDisabled` (the `$` prefix tells styled-components to treat it as a transient prop) prevents this invalid HTML attribute from appearing on the rendered `<a>` tag.

This matches the same fix already done for `PathsCardButton` in PR #194.

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes