### PR TITLE
fix: update stale master branch references to main in component URLs

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -605,7 +605,7 @@ export const Community = () => (
         ))}
         <CTAWrapper>
           <CTASecondary
-            href="https://github.com/andrerfneves/lightning-address/blob/master/README.md#wallets-supported"
+            href="https://github.com/andrerfneves/lightning-address/blob/main/README.md#wallets-supported"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/components/footer.js
+++ b/components/footer.js
@@ -12,7 +12,7 @@ const FOOTER = [
     title: "Resources",
     items: [
       {
-        link: "https://github.com/andrerfneves/lightning-address/blob/master/README.md",
+        link: "https://github.com/andrerfneves/lightning-address/blob/main/README.md",
         title: "Dev Documentation",
       },
       {

--- a/components/hero.js
+++ b/components/hero.js
@@ -261,11 +261,11 @@ export function Hero() {
         >
           <CTAWrapper>
             <CTAPrimary href="#providers">Get a Lightning Address</CTAPrimary>
-            <CTASecondary href="https://github.com/andrerfneves/lightning-address/blob/master/README.md" target="_blank" rel="noopener noreferrer">Read Documentation</CTASecondary>
+            <CTASecondary href="https://github.com/andrerfneves/lightning-address/blob/main/README.md" target="_blank" rel="noopener noreferrer">Read Documentation</CTASecondary>
           </CTAWrapper>
           <LicenseWrapper>
             <LicenseText>License: MIT</LicenseText>
-            <LicenseLink href='https://github.com/andrerfneves/lightning-address/blob/master/LICENSE.md' target='_blank' rel="noopener noreferrer">GitHub</LicenseLink>
+            <LicenseLink href='https://github.com/andrerfneves/lightning-address/blob/main/LICENSE.md' target='_blank' rel="noopener noreferrer">GitHub</LicenseLink>
           </LicenseWrapper>
         </HeroSection>
       )}

--- a/components/paths.js
+++ b/components/paths.js
@@ -168,7 +168,7 @@ const IMPLEMENTATIONS = [
     description: 'Lightning Address is just a set of simple protocol instructions. Whether you are a Bitcoin service provider or simply an enthusiast interested in running your own setup, this is where you get started supporting this new standard.',
     image: '/images/data2.svg',
     linkText: 'Learn More',
-    link: 'https://github.com/andrerfneves/lightning-address/blob/master/DIY.md',
+    link: 'https://github.com/andrerfneves/lightning-address/blob/main/DIY.md',
     isSecondary: true,
     isInternal: false,
   },


### PR DESCRIPTION
## Summary

All GitHub blob URLs across components still pointed to the old default branch name `master`. Since this repo uses `main`, update links to use the correct branch and avoid unnecessary redirects.

## Changes

| File | Link |
|------|------|
| `components/hero.js` (x2) | README.md, LICENSE.md |
| `components/footer.js` | README.md |
| `components/paths.js` | DIY.md |
| `components/community.js` | README.md#wallets-supported |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes