### PR TITLE
fix: correct stale wallet name and URL in community and footer sections

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -490,7 +490,7 @@ const WALLETS = [
     },
   },
   {
-    name: "Satoshi Wallet",
+    name: "Satoshi Lightning",
     image: "https://vipsats.app/img/satoshi.png",
     downloadText: "Download Satoshi",
     url: "https://vipsats.app",

--- a/components/footer.js
+++ b/components/footer.js
@@ -49,7 +49,7 @@ const FOOTER = [
         title: "BlueWallet",
       },
       {
-        link: "https://blixtwallet.com/",
+        link: "https://blixtwallet.github.io/",
         title: "Blixt Wallet",
       },
       {


### PR DESCRIPTION
## Summary

Two data correctness fixes in the wallet directory sections:

1. **`components/community.js`** — Renamed "Satoshi Wallet" to "Satoshi Lightning" in the `WALLETS` array to match the naming used in `providers.js`, `footer.js`, and the README.

2. **`components/footer.js`** — Updated the Blixt Wallet URL from `blixtwallet.com` (which redirects) to the canonical `blixtwallet.github.io`, matching the URL used in `community.js` and the README.

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes