### PR TITLE
refactor: extract shared Card and ImageWrapper styled components

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media, CTASecondary as BaseCTASecondary } from "../utils";
+import { media, CTASecondary as BaseCTASecondary, ImageWrapper, Card } from "../utils";
 
 const CommunityModule = styled.div`
   display: flex;
@@ -104,28 +104,6 @@ const CommunityRightInner = styled.div`
   `}
 `;
 
-const CommunityCard = styled.div`
-  margin: 20px auto 20px auto;
-  display: flex;
-  padding: 16px;
-  min-height: 100px;
-  border-radius: 6px;
-  align-items: center;
-  flex-direction: column;
-  background-color: #fff;
-  justify-content: center;
-  box-shadow: 0px 30px 60px rgb(0 0 0 / 12%);
-
-  ${media.tablet`
-    width: 425px;
-    height: 42px;
-    margin: 20px 0;
-    min-height: auto;
-    flex-direction: row;
-    justify-content: space-between;
-  `}
-`;
-
 const CommunitySignUpButton = styled.a`
   color: #fff;
   width: 140px;
@@ -155,18 +133,6 @@ const CommunitySignUpButton = styled.a`
 const Image = styled.img`
   width: 130px;
   align-self: center;
-`;
-
-const ImageWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  justify-content: center;
-  flex: 1;
-
-  ${media.tablet`
-    padding-right: 15px;
-  `}
 `;
 
 const CommunityListWrapper = styled.div`
@@ -590,7 +556,7 @@ export const Community = () => (
           easily as you send emails.
         </CommunityDescriptionSmall>
         {WALLETS.map((wallet) => (
-          <CommunityCard key={wallet.name}>
+          <Card key={wallet.name}>
             <ImageWrapper>
               <Image
                 src={wallet.image}
@@ -601,7 +567,7 @@ export const Community = () => (
             <CommunitySignUpButton target="_blank" rel="noopener noreferrer" href={wallet.url}>
               {wallet.downloadText}
             </CommunitySignUpButton>
-          </CommunityCard>
+          </Card>
         ))}
         <CTAWrapper>
           <CTASecondary

--- a/components/providers.js
+++ b/components/providers.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media } from "../utils";
+import { media, ImageWrapper, Card } from "../utils";
 
 const ProvidersModule = styled.div`
   display: flex;
@@ -146,28 +146,6 @@ const ProvidersEmailButtonText = styled.span`
   `}
 `;
 
-const ProviderCard = styled.div`
-  margin: 20px auto 20px auto;
-  display: flex;
-  padding: 16px;
-  min-height: 100px;
-  border-radius: 6px;
-  align-items: center;
-  flex-direction: column;
-  background-color: #fff;
-  justify-content: center;
-  box-shadow: 0px 30px 60px rgb(0 0 0 / 12%);
-
-  ${media.tablet`
-    width: 425px;
-    height: 42px;
-    margin: 20px 0;
-    min-height: auto;
-    flex-direction: row;
-    justify-content: space-between;
-  `}
-`;
-
 const ProviderSignUpButton = styled.a`
   color: #fff;
   width: 140px;
@@ -193,18 +171,6 @@ const ProviderSignUpButton = styled.a`
   ${media.tablet`
     min-width: 220px;
     margin: 0 15px 0 0;
-  `}
-`;
-
-const ImageWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  justify-content: center;
-  flex: 1;
-
-  ${media.tablet`
-    padding-right: 15px;
   `}
 `;
 
@@ -457,7 +423,7 @@ export const Providers = () => (
           services that already support it. You’ll be set up in seconds!
         </ProvidersDescription>
         {PROVIDERS.map((provider) => (
-          <ProviderCard key={provider.name}>
+          <Card key={provider.name}>
             <ImageWrapper>
               <img
                 src={provider.image}
@@ -474,7 +440,7 @@ export const Providers = () => (
             >
               {provider.buttonText || `Open ${provider.name}`}
             </ProviderSignUpButton>
-          </ProviderCard>
+          </Card>
         ))}
       </ProvidersLeft>
       <ProvidersRight>

--- a/utils.js
+++ b/utils.js
@@ -69,3 +69,37 @@ export const CTASecondary = styled.a`
     margin: 0 0 0 15px;
   `}
 `;
+
+export const Card = styled.div`
+  margin: 20px auto 20px auto;
+  display: flex;
+  padding: 16px;
+  min-height: 100px;
+  border-radius: 6px;
+  align-items: center;
+  flex-direction: column;
+  background-color: #fff;
+  justify-content: center;
+  box-shadow: 0px 30px 60px rgb(0 0 0 / 12%);
+
+  ${media.tablet`
+    width: 425px;
+    height: 42px;
+    margin: 20px 0;
+    min-height: auto;
+    flex-direction: row;
+    justify-content: space-between;
+  `}
+`;
+
+export const ImageWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  flex: 1;
+
+  ${media.tablet`
+    padding-right: 15px;
+  `}
+`;


### PR DESCRIPTION
## Summary

`ProviderCard` / `CommunityCard` and `ImageWrapper` were exact styled-component copies in both `providers.js` and `community.js`. This extracts them to `utils.js` as shared `Card` and `ImageWrapper` components, following the same cleanup pattern established in PR #187 (shared `CTASignUpButton`) and PR #181 (shared `CTASecondary`).

## Changes

| File | Change |
|------|--------|
| `utils.js` | Added shared `Card` and `ImageWrapper` styled components |
| `providers.js` | Import shared components; removed local `ProviderCard` and `ImageWrapper` |
| `community.js` | Import shared components; removed local `CommunityCard` and `ImageWrapper` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes