### PR TITLE
perf: load Google Fonts via <link> tag instead of @import

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,8 +1,6 @@
 import { createGlobalStyle, ThemeProvider } from 'styled-components'
 
 const GlobalStyle = createGlobalStyle`
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@200;400;500;700;900&display=swap');
-
   body {
     margin: 0;
     padding: 0;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -31,7 +31,11 @@ export default class MyDocument extends Document {
   render() {
     return (
       <Html lang="en">
-        <Head />
+        <Head>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+          <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;400;500;700;900&display=swap" rel="stylesheet" />
+        </Head>
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
## Summary

The Google Fonts loading was done via `@import url(...)` inside styled-components' `createGlobalStyle`. This blocks font loading because the browser must parse the entire CSS stylesheet before discovering the font resource. Moving to standard `<link>` tags in `_document.js` lets the browser discover and start fetching the font sooner, improving perceived performance.

## Changes

- **`pages/_app.js`** — Removed `@import url(...)` from `GlobalStyle`
- **`pages/_document.js`** — Added `<link rel=\preconnect\>` for both Google Fonts domains and a `<link rel=\stylesheet\>` for the Inter font family

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No visual changes — the same `font-family: 'Inter', sans-serif` is still applied via `GlobalStyle`
- [x] Font is loaded via the standard Google Fonts approach (preconnect + stylesheet link)