### PR TITLE
refactor: extract shared SectionIntro styled component

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media, CTASecondary as BaseCTASecondary } from "../utils";
+import { media, SectionIntro, CTASecondary as BaseCTASecondary } from "../utils";
 
 const CommunityModule = styled.div`
   display: flex;
@@ -49,22 +49,6 @@ const CommunityDescription = styled.div`
     padding: 0;
     font-size: 20px;
     line-height: 1.6;
-  `}
-`;
-
-const CommunityIntro = styled.p`
-  color: #f38800;
-  font-size: 14px;
-  line-height: 1.6;
-  max-width: 900px;
-  font-weight: 500;
-  padding: 8px 12px;
-  border-radius: 7px;
-  margin: 0 auto 20px auto;
-  background: rgba(255, 97, 0, 0.1);
-
-  ${media.tablet`
-    font-size: 18px;
   `}
 `;
 
@@ -571,7 +555,7 @@ const WALLETS = [
 
 export const Community = () => (
   <CommunityModule id="community">
-    <CommunityIntro>Community Efforts & Tools</CommunityIntro>
+    <SectionIntro>Community Efforts & Tools</SectionIntro>
     <CommunityTitle>Noncustodial Bridge Servers</CommunityTitle>
     <CommunityDescription>
       The Lightning Address standard continues to be adopted by community

--- a/components/paths.js
+++ b/components/paths.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { media } from '../utils';
+import { media, SectionIntro } from '../utils';
 
 const PathsModule = styled.div`
   display: flex;
@@ -128,22 +128,6 @@ const PathsCardButton = styled.a`
   }
 `;
 
-const PathsIntro = styled.p`
-  color: #f38800;
-  font-size: 14px;
-  line-height: 1.6;
-  max-width: 900px;
-  font-weight: 500;
-  padding: 8px 12px;
-  border-radius: 7px;
-  margin: 0 auto 20px auto;
-  background: rgba(255,97,0,0.1);
-
-  ${media.tablet`
-    font-size: 18px;
-  `}
-`;
-
 const IMPLEMENTATIONS = [
   {
     title: 'Apps & Services',
@@ -176,7 +160,7 @@ const IMPLEMENTATIONS = [
 
 export const Paths = () => (
   <PathsModule>
-    <PathsIntro>Developers & Shadowy Coders</PathsIntro>
+    <SectionIntro>Developers & Shadowy Coders</SectionIntro>
     <PathsTitle>Integrates as fast as Lightning</PathsTitle>
     <PathsDescription>
       We’ve made it exceedingly straightforward to start supporting Lightning Addresses on your own domain or integrate them with the apps you’re building. Set up support for this new standard today and join the era of total Lightning interoperability!

--- a/utils.js
+++ b/utils.js
@@ -69,3 +69,19 @@ export const CTASecondary = styled.a`
     margin: 0 0 0 15px;
   `}
 `;
+
+export const SectionIntro = styled.p`
+  color: #f38800;
+  font-size: 14px;
+  line-height: 1.6;
+  max-width: 900px;
+  font-weight: 500;
+  padding: 8px 12px;
+  border-radius: 7px;
+  margin: 0 auto 20px auto;
+  background: rgba(255, 97, 0, 0.1);
+
+  ${media.tablet`
+    font-size: 18px;
+  `}
+`;


### PR DESCRIPTION
## Summary

`CommunityIntro` (in `community.js`) and `PathsIntro` (in `paths.js`) were exact duplicate styled components — same color, sizing, padding, border-radius, background, and responsive breakpoint. This extracts them to `utils.js` as a shared `SectionIntro` component.

This follows the same cleanup pattern established in:
- PR #181 — shared `CTASecondary`
- PR #187 — shared `CTASignUpButton`
- PR #200 — shared `Card` and `ImageWrapper`

## Changes

| File | Change |
|------|--------|
| `utils.js` | Added shared `SectionIntro` styled component |
| `components/community.js` | Import shared `SectionIntro`; removed local `CommunityIntro` |
| `components/paths.js` | Import shared `SectionIntro`; removed local `PathsIntro` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes