### PR TITLE
fix: add missing Inter font weights 600 and 800 to Google Fonts URL

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,7 @@
 import { createGlobalStyle, ThemeProvider } from 'styled-components'
 
 const GlobalStyle = createGlobalStyle`
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@200;400;500;700;900&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@200;400;500;600;700;800;900&display=swap');
 
   body {
     margin: 0;


### PR DESCRIPTION
## Summary

The Google Fonts URL in `_app.js` only requested font weights 200, 400, 500, 700, and 900, but the codebase uses `font-weight: 600` (4 occurrences) and `font-weight: 800` (8 occurrences) extensively for titles and bold text elements.

Without the correct weights loaded, the browser falls back to the nearest available weight (700 for 800-weight elements, 500 for 600-weight elements), causing titles and bold spans to render in the wrong weight.

### Affected components (font-weight: 800)
- **hero.js** — Hero `Title`
- **benefits.js** — `BenefitsTitle`
- **paths.js** — `PathsTitle`
- **providers.js** — `ProvidersTitle`
- **community.js** — `CommunityTitle`, `CommunitySectionTitle`
- **footer.js** — `BottomLogo`

### Affected components (font-weight: 600)
- **hero.js** — `Bold` span
- **benefits.js** — `BenefitsCardTitle`
- **paths.js** — `PathsCardTitle`
- **providers.js** — `ProvidersEmailButtonText`

## Changes

| File | Change |
|------|--------|
| `pages/_app.js` | Added `600` and `800` to the Google Fonts `wght` parameter |

## Notes

This fix applies to the current `@import`-based font loading in `_app.js`. PR #201 (perf: load Google Fonts via `<link>` tag) moves the font loading to `_document.js` — when that merges, the updated weights list should be carried forward to the new `<link>` tag.

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual regressions