### PR TITLE
refactor: extract shared SectionTitle styled component

### DIFF
--- a/components/benefits.js
+++ b/components/benefits.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { media, CTAPrimary } from '../utils';
+import { media, CTAPrimary, SectionTitle } from '../utils';
 
 const BenefitsModule = styled.div`
   display: flex;
@@ -14,23 +14,6 @@ const BenefitsModule = styled.div`
   ${media.tablet`
     min-height: 700px;
     padding: 120px 0 120px 0;
-  `}
-`;
-
-const BenefitsTitle = styled.div`
-  margin: 0 auto;
-  font-size: 30px;
-  padding: 0 30px;
-  max-width: 500px;
-  font-weight: 800;
-  line-height: 1.3;
-  text-align: center;
-  letter-spacing: -0.5px;
-
-  ${media.tablet`
-    padding: 0;
-    font-size: 44px;
-    letter-spacing: -1px;
   `}
 `;
 
@@ -178,7 +161,7 @@ const BENEFITS = [
 export const Benefits = () => (
   <BenefitsModule>
     <BenefitsIntro>Users & Enthusiasts</BenefitsIntro>
-    <BenefitsTitle>Why do I need a Lightning Address?</BenefitsTitle>
+    <SectionTitle>Why do I need a Lightning Address?</SectionTitle>
     <BenefitsDescription>We created the Lightning Address protocol to empower everyone to send money like we send emails — instantly and abundantly. Coupled with the Lightning Network’s ability to send Bitcoin instantly and with (almost) no fees, we’re ushering in a new standard for how value moves around the world.</BenefitsDescription>
     <BenefitsCardGrid>
       {(BENEFITS || []).map((benefit) => (

--- a/components/community.js
+++ b/components/community.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media, CTASecondary as BaseCTASecondary } from "../utils";
+import { media, CTASecondary as BaseCTASecondary, SectionTitle } from "../utils";
 
 const CommunityModule = styled.div`
   display: flex;
@@ -14,23 +14,6 @@ const CommunityModule = styled.div`
   ${media.tablet`
     min-height: 700px;
     padding: 120px 0 120px 0;
-  `}
-`;
-
-const CommunityTitle = styled.div`
-  margin: 0 auto;
-  font-size: 30px;
-  padding: 0 30px;
-  max-width: 500px;
-  font-weight: 800;
-  line-height: 1.3;
-  text-align: center;
-  letter-spacing: -0.5px;
-
-  ${media.tablet`
-    padding: 0;
-    font-size: 44px;
-    letter-spacing: -1px;
   `}
 `;
 
@@ -572,7 +555,7 @@ const WALLETS = [
 export const Community = () => (
   <CommunityModule id="community">
     <CommunityIntro>Community Efforts & Tools</CommunityIntro>
-    <CommunityTitle>Noncustodial Bridge Servers</CommunityTitle>
+    <SectionTitle>Noncustodial Bridge Servers</SectionTitle>
     <CommunityDescription>
       The Lightning Address standard continues to be adopted by community
       participants and companies in the industry. From mobile and desktop wallet

--- a/components/paths.js
+++ b/components/paths.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { media } from '../utils';
+import { media, SectionTitle } from '../utils';
 
 const PathsModule = styled.div`
   display: flex;
@@ -13,23 +13,6 @@ const PathsModule = styled.div`
   ${media.tablet`
     min-height: 700px;
     padding: 120px 0 120px 0;
-  `}
-`;
-
-const PathsTitle = styled.div`
-  margin: 0 auto;
-  font-size: 30px;
-  padding: 0 30px;
-  max-width: 500px;
-  font-weight: 800;
-  line-height: 1.3;
-  text-align: center;
-  letter-spacing: -0.5px;
-
-  ${media.tablet`
-    padding: 0;
-    font-size: 44px;
-    letter-spacing: -1px;
   `}
 `;
 
@@ -177,7 +160,7 @@ const IMPLEMENTATIONS = [
 export const Paths = () => (
   <PathsModule>
     <PathsIntro>Developers & Shadowy Coders</PathsIntro>
-    <PathsTitle>Integrates as fast as Lightning</PathsTitle>
+    <SectionTitle>Integrates as fast as Lightning</SectionTitle>
     <PathsDescription>
       We’ve made it exceedingly straightforward to start supporting Lightning Addresses on your own domain or integrate them with the apps you’re building. Set up support for this new standard today and join the era of total Lightning interoperability!
     </PathsDescription>

--- a/utils.js
+++ b/utils.js
@@ -46,6 +46,23 @@ export const CTAPrimary = styled.a`
   `}
 `;
 
+export const SectionTitle = styled.div`
+  margin: 0 auto;
+  font-size: 30px;
+  padding: 0 30px;
+  max-width: 500px;
+  font-weight: 800;
+  line-height: 1.3;
+  text-align: center;
+  letter-spacing: -0.5px;
+
+  ${media.tablet`
+    padding: 0;
+    font-size: 44px;
+    letter-spacing: -1px;
+  `}
+`;
+
 export const CTASecondary = styled.a`
   color: #696969;
   cursor: pointer;


### PR DESCRIPTION
## Summary

`BenefitsTitle` (in `benefits.js`), `PathsTitle` (in `paths.js`), and `CommunityTitle` (in `community.js`) were exact duplicate styled components — same margin, sizing, font-weight, letter-spacing, and responsive breakpoint. This extracts them to `utils.js` as a shared `SectionTitle` component.

This follows the same cleanup pattern established in:
- PR #181 — shared `CTASecondary`
- PR #187 — shared `CTASignUpButton`
- PR #200 — shared `Card` and `ImageWrapper`
- PR #203 — shared `SectionIntro`

## Changes

| File | Change |
|------|--------|
| `utils.js` | Added shared `SectionTitle` styled component |
| `components/benefits.js` | Import shared `SectionTitle`; removed local `BenefitsTitle` |
| `components/paths.js` | Import shared `SectionTitle`; removed local `PathsTitle` |
| `components/community.js` | Import shared `SectionTitle`; removed local `CommunityTitle` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes