### PR TITLE
refactor: extract shared SectionDescription styled component

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media, CTASecondary as BaseCTASecondary } from "../utils";
+import { media, CTASecondary as BaseCTASecondary, SectionDescription } from "../utils";
 
 const CommunityModule = styled.div`
   display: flex;
@@ -31,24 +31,6 @@ const CommunityTitle = styled.div`
     padding: 0;
     font-size: 44px;
     letter-spacing: -1px;
-  `}
-`;
-
-const CommunityDescription = styled.div`
-  color: #666666;
-  font-size: 16px;
-  line-height: 1.4;
-  padding: 0 30px;
-  font-weight: 400;
-  max-width: 800px;
-  text-align: center;
-  letter-spacing: -1px;
-  margin: 20px auto 0 auto;
-
-  ${media.tablet`
-    padding: 0;
-    font-size: 20px;
-    line-height: 1.6;
   `}
 `;
 
@@ -245,7 +227,7 @@ const VerticalLink = styled.a`
   }
 `;
 
-const CommunityDescriptionSmall = styled(CommunityDescription)`
+const CommunityDescriptionSmall = styled(SectionDescription)`
   text-align: center;
 
   ${media.tablet`
@@ -573,12 +555,12 @@ export const Community = () => (
   <CommunityModule id="community">
     <CommunityIntro>Community Efforts & Tools</CommunityIntro>
     <CommunityTitle>Noncustodial Bridge Servers</CommunityTitle>
-    <CommunityDescription>
+    <SectionDescription>
       The Lightning Address standard continues to be adopted by community
       participants and companies in the industry. From mobile and desktop wallet
       support, to federated Lightning Address bridge servers anyone can
       self-host, it's never been easier to transact Bitcoin.
-    </CommunityDescription>
+    </SectionDescription>
     <CommunityInner>
       <CommunityLeft>
         <CommunitySectionTitle>

--- a/components/paths.js
+++ b/components/paths.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { media } from '../utils';
+import { media, SectionDescription } from '../utils';
 
 const PathsModule = styled.div`
   display: flex;
@@ -30,24 +30,6 @@ const PathsTitle = styled.div`
     padding: 0;
     font-size: 44px;
     letter-spacing: -1px;
-  `}
-`;
-
-const PathsDescription = styled.div`
-  color: #666666;
-  font-size: 16px;
-  line-height: 1.4;
-  padding: 0 30px;
-  font-weight: 400;
-  max-width: 800px;
-  text-align: center;
-  letter-spacing: -1px;
-  margin: 20px auto 0 auto;
-
-  ${media.tablet`
-    padding: 0;
-    font-size: 20px;
-    line-height: 1.6;
   `}
 `;
 
@@ -178,9 +160,9 @@ export const Paths = () => (
   <PathsModule>
     <PathsIntro>Developers & Shadowy Coders</PathsIntro>
     <PathsTitle>Integrates as fast as Lightning</PathsTitle>
-    <PathsDescription>
+    <SectionDescription>
       We’ve made it exceedingly straightforward to start supporting Lightning Addresses on your own domain or integrate them with the apps you’re building. Set up support for this new standard today and join the era of total Lightning interoperability!
-    </PathsDescription>
+    </SectionDescription>
     <PathsCardGrid>
       {(IMPLEMENTATIONS || []).map((benefit) => (
         <PathsCard key={benefit.title}>

--- a/utils.js
+++ b/utils.js
@@ -22,6 +22,24 @@ export const media = Object.keys(sizes).reduce((acc, label) => {
   return acc;
 }, {});
 
+export const SectionDescription = styled.div`
+  color: #666666;
+  font-size: 16px;
+  line-height: 1.4;
+  padding: 0 30px;
+  font-weight: 400;
+  max-width: 800px;
+  text-align: center;
+  letter-spacing: -1px;
+  margin: 20px auto 0 auto;
+
+  ${media.tablet`
+    padding: 0;
+    font-size: 20px;
+    line-height: 1.6;
+  `}
+`;
+
 export const CTAPrimary = styled.a`
   color: #fff;
   height: 2.81rem;


### PR DESCRIPTION
## Summary

`PathsDescription` (in `paths.js`) and `CommunityDescription` (in `community.js`) were exact duplicate styled components — same color, sizing, padding, font-weight, responsive breakpoint, and all other styles. This extracts them to `utils.js` as a shared `SectionDescription` component.

`CommunityDescriptionSmall` and `VerticalLinkDescription` (both in `community.js`) continue to extend `SectionDescription` via styled-components inheritance.

This follows the same cleanup pattern established in:
- PR #181 — shared `CTASecondary`
- PR #187 — shared `CTASignUpButton`
- PR #200 — shared `Card` and `ImageWrapper`
- PR #203 — shared `SectionIntro`

## Changes

| File | Change |
|------|--------|
| `utils.js` | Added shared `SectionDescription` styled component |
| `components/paths.js` | Import shared `SectionDescription`; removed local `PathsDescription` |
| `components/community.js` | Import shared `SectionDescription`; removed local `CommunityDescription`; `CommunityDescriptionSmall` now extends `SectionDescription` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes