### PR TITLE
refactor: extract shared layout components from providers and community sections

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media, CTASecondary as BaseCTASecondary } from "../utils";
+import { media, CTASecondary as BaseCTASecondary, SectionLeft, SectionRight, SectionRightInner } from "../utils";
 
 const CommunityModule = styled.div`
   display: flex;
@@ -79,28 +79,6 @@ const CommunityInner = styled.div`
     margin-top: 80px;
     max-width: 1000px;
     flex-direction: row;
-  `}
-`;
-
-const CommunityLeft = styled.div`
-  padding-bottom: 60px;
-
-  ${media.largeTablet`
-    flex: 1;
-    padding-bottom: 0;
-    padding-right: 10px;
-  `}
-`;
-
-const CommunityRight = styled.div`
-  ${media.largeTablet`
-    flex: 1;
-  `}
-`;
-
-const CommunityRightInner = styled.div`
-  ${media.largeTablet`
-    padding-left: 100px;
   `}
 `;
 
@@ -580,7 +558,7 @@ export const Community = () => (
       self-host, it's never been easier to transact Bitcoin.
     </CommunityDescription>
     <CommunityInner>
-      <CommunityLeft>
+      <SectionLeft>
         <CommunitySectionTitle>
           Transact with a Lightning Address today!
         </CommunitySectionTitle>
@@ -612,9 +590,9 @@ export const Community = () => (
             View list of supported Wallets
           </CTASecondary>
         </CTAWrapper>
-      </CommunityLeft>
-      <CommunityRight>
-        <CommunityRightInner>
+      </SectionLeft>
+      <SectionRight>
+        <SectionRightInner>
           <CommunitySectionTitle>
             Want a different domain for your Lightning Address?
           </CommunitySectionTitle>
@@ -646,8 +624,8 @@ export const Community = () => (
               </VerticalLinkWrapper>
             ))}
           </CommunityVerticalListWrapper>
-        </CommunityRightInner>
-      </CommunityRight>
+        </SectionRightInner>
+      </SectionRight>
     </CommunityInner>
   </CommunityModule>
 );

--- a/components/providers.js
+++ b/components/providers.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media } from "../utils";
+import { media, SectionLeft, SectionRight, SectionRightInner } from "../utils";
 
 const ProvidersModule = styled.div`
   display: flex;
@@ -26,28 +26,6 @@ const ProvidersInner = styled.div`
   ${media.largeTablet`
     max-width: 1000px;
     flex-direction: row;
-  `}
-`;
-
-const ProvidersLeft = styled.div`
-  padding-bottom: 60px;
-
-  ${media.largeTablet`
-    flex: 1;
-    padding-bottom: 0;
-    padding-right: 10px;
-  `}
-`;
-
-const ProvidersRight = styled.div`
-  ${media.largeTablet`
-    flex: 1;
-  `}
-`;
-
-const ProvidersRightInner = styled.div`
-  ${media.largeTablet`
-    padding-left: 100px;
   `}
 `;
 
@@ -450,7 +428,7 @@ const PROVIDERS = [
 export const Providers = () => (
   <ProvidersModule id="providers">
     <ProvidersInner>
-      <ProvidersLeft>
+      <SectionLeft>
         <ProvidersTitle>Get a Lightning Address now!</ProvidersTitle>
         <ProvidersDescription>
           Get your own Lightning Address now by using one of the apps and
@@ -476,9 +454,9 @@ export const Providers = () => (
             </ProviderSignUpButton>
           </ProviderCard>
         ))}
-      </ProvidersLeft>
-      <ProvidersRight>
-        <ProvidersRightInner>
+      </SectionLeft>
+      <SectionRight>
+        <SectionRightInner>
           <ProvidersTitle>
             Your app doesn't support Lightning Addresses yet?
           </ProvidersTitle>
@@ -502,8 +480,8 @@ export const Providers = () => (
             <ProvidersEmailButtonImage src={"/images/email.svg"} alt="Email" />
             <ProvidersEmailButtonText>Send Email</ProvidersEmailButtonText>
           </ProvidersEmailButton>
-        </ProvidersRightInner>
-      </ProvidersRight>
+        </SectionRightInner>
+      </SectionRight>
     </ProvidersInner>
   </ProvidersModule>
 );

--- a/utils.js
+++ b/utils.js
@@ -22,6 +22,28 @@ export const media = Object.keys(sizes).reduce((acc, label) => {
   return acc;
 }, {});
 
+export const SectionLeft = styled.div`
+  padding-bottom: 60px;
+
+  ${media.largeTablet`
+    flex: 1;
+    padding-bottom: 0;
+    padding-right: 10px;
+  `}
+`;
+
+export const SectionRight = styled.div`
+  ${media.largeTablet`
+    flex: 1;
+  `}
+`;
+
+export const SectionRightInner = styled.div`
+  ${media.largeTablet`
+    padding-left: 100px;
+  `}
+`;
+
 export const CTAPrimary = styled.a`
   color: #fff;
   height: 2.81rem;


### PR DESCRIPTION
## Summary

`ProvidersLeft`/`CommunityLeft`, `ProvidersRight`/`CommunityRight`, and `ProvidersRightInner`/`CommunityRightInner` were exact duplicate styled component pairs in `providers.js` and `community.js`. This extracts them to `utils.js` as shared `SectionLeft`, `SectionRight`, and `SectionRightInner` components.

This follows the same cleanup pattern established in:
- PR #181 — shared `CTASecondary`
- PR #187 — shared `CTASignUpButton`
- PR #200 — shared `Card` and `ImageWrapper`
- PR #203 — shared `SectionIntro`

## Changes

| File | Change |
|------|--------|
| `utils.js` | Added shared `SectionLeft`, `SectionRight`, `SectionRightInner` styled components |
| `components/providers.js` | Import shared components; removed local `ProvidersLeft`, `ProvidersRight`, `ProvidersRightInner` |
| `components/community.js` | Import shared components; removed local `CommunityLeft`, `CommunityRight`, `CommunityRightInner` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes