### PR TITLE
refactor: extract shared SectionBase styled component

### DIFF
--- a/components/benefits.js
+++ b/components/benefits.js
@@ -1,20 +1,10 @@
 import styled from 'styled-components';
 
-import { media, CTAPrimary } from '../utils';
+import { media, CTAPrimary, SectionBase } from '../utils';
 
-const BenefitsModule = styled.div`
-  display: flex;
+const BenefitsModule = styled(SectionBase)`
   background: #fafafa;
-  align-items: center;
-  padding: 60px 0 60px 0;
-  flex-direction: column;
-  justify-content: center;
   border-bottom: 1px solid #eaeaea;
-
-  ${media.tablet`
-    min-height: 700px;
-    padding: 120px 0 120px 0;
-  `}
 `;
 
 const BenefitsTitle = styled.div`

--- a/components/community.js
+++ b/components/community.js
@@ -1,20 +1,10 @@
 import styled from "styled-components";
 
-import { media, CTASecondary as BaseCTASecondary } from "../utils";
+import { media, CTASecondary as BaseCTASecondary, SectionBase } from "../utils";
 
-const CommunityModule = styled.div`
-  display: flex;
+const CommunityModule = styled(SectionBase)`
   background: #fff;
-  align-items: center;
-  flex-direction: column;
-  padding: 60px 0 60px 0;
-  justify-content: center;
   border-top: 1px solid #eaeaea;
-
-  ${media.tablet`
-    min-height: 700px;
-    padding: 120px 0 120px 0;
-  `}
 `;
 
 const CommunityTitle = styled.div`

--- a/components/paths.js
+++ b/components/paths.js
@@ -1,19 +1,9 @@
 import styled from 'styled-components';
 
-import { media } from '../utils';
+import { media, SectionBase } from '../utils';
 
-const PathsModule = styled.div`
-  display: flex;
+const PathsModule = styled(SectionBase)`
   background: #fff;
-  align-items: center;
-  flex-direction: column;
-  padding: 60px 0 60px 0;
-  justify-content: center;
-
-  ${media.tablet`
-    min-height: 700px;
-    padding: 120px 0 120px 0;
-  `}
 `;
 
 const PathsTitle = styled.div`

--- a/components/providers.js
+++ b/components/providers.js
@@ -1,20 +1,10 @@
 import styled from "styled-components";
 
-import { media } from "../utils";
+import { media, SectionBase } from "../utils";
 
-const ProvidersModule = styled.div`
-  display: flex;
+const ProvidersModule = styled(SectionBase)`
   background: #fafafa;
-  align-items: center;
-  flex-direction: column;
-  justify-content: center;
-  padding: 60px 0 60px 0;
   border-top: 1px solid #eaeaea;
-
-  ${media.tablet`
-    min-height: 700px;
-    padding: 120px 0 120px 0;
-  `}
 `;
 
 const ProvidersInner = styled.div`

--- a/utils.js
+++ b/utils.js
@@ -22,6 +22,19 @@ export const media = Object.keys(sizes).reduce((acc, label) => {
   return acc;
 }, {});
 
+export const SectionBase = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  padding: 60px 0 60px 0;
+  justify-content: center;
+
+  ${media.tablet`
+    min-height: 700px;
+    padding: 120px 0 120px 0;
+  `}
+`;
+
 export const CTAPrimary = styled.a`
   color: #fff;
   height: 2.81rem;


### PR DESCRIPTION
## Summary

`BenefitsModule` (in `benefits.js`), `PathsModule` (in `paths.js`), `ProvidersModule` (in `providers.js`), and `CommunityModule` (in `community.js`) were near-identical styled components sharing the same layout properties — `display: flex`, `align-items: center`, `flex-direction: column`, `padding: 60px 0`, `justify-content: center`, and the same `media.tablet` responsive breakpoint (min-height and padding overrides).

This extracts them to `utils.js` as a shared `SectionBase` component. Each module now extends `SectionBase` with only its specific `background` and `border` settings.

This follows the same cleanup pattern established in:
- PR #181 — shared `CTASecondary`
- PR #187 — shared `CTASignUpButton`
- PR #200 — shared `Card` and `ImageWrapper`
- PR #203 — shared `SectionIntro`
- PR #205 — shared `SectionTitle`
- PR #206 — shared `SectionDescription`
- PR #207 — shared `SectionLeft`, `SectionRight`, `SectionRightInner`

## Changes

| File | Change |
|------|--------|
| `utils.js` | Added shared `SectionBase` styled component |
| `components/benefits.js` | Import `SectionBase`; `BenefitsModule` extends `SectionBase` |
| `components/paths.js` | Import `SectionBase`; `PathsModule` extends `SectionBase` |
| `components/providers.js` | Import `SectionBase`; `ProvidersModule` extends `SectionBase` |
| `components/community.js` | Import `SectionBase`; `CommunityModule` extends `SectionBase` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes