### PR TITLE
refactor: make VerticalLink extend Link styled component

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -222,27 +222,13 @@ const Link = styled.a`
   }
 `;
 
-const VerticalLink = styled.a`
-  color: #0070f3;
+const VerticalLink = styled(Link)`
   display: block;
-  font-size: 14px;
-  line-height: 1.6;
   max-height: 22px;
-  font-weight: 500;
-  padding: 8px 12px;
-  border-radius: 7px;
-  text-decoration: none;
-  margin: 10px 10px 0 0;
-  background: rgba(0, 118, 255, 0.1);
 
   ${media.tablet`
-    font-size: 14px;
-    line-height: 1.6;
+    max-width: none;
   `}
-
-  &:hover {
-    background: rgba(0, 118, 255, 0.2);
-  }
 `;
 
 const CommunityDescriptionSmall = styled(CommunityDescription)`


### PR DESCRIPTION
## Summary

`VerticalLink` (in `community.js`) was an almost exact copy of `Link` with only two additional properties (`display: block`, `max-height: 22px`) and one omission (no `max-width: 900px` in the tablet media query).

This makes `VerticalLink` extend `Link` via styled-components inheritance, keeping only the unique `display: block` and `max-height: 22px` properties, and overriding `max-width` to `none` in the tablet breakpoint to match the original behavior.

This follows the same cleanup pattern established in:
- PR #181 — shared `CTASecondary`
- PR #187 — shared `CTASignUpButton`
- PR #200 — shared `Card` and `ImageWrapper`
- PR #203 — shared `SectionIntro`
- PR #205 — shared `SectionTitle`
- PR #206 — shared `SectionDescription`
- PR #207 — shared `SectionLeft`, `SectionRight`, `SectionRightInner`

## Changes

| File | Change |
|------|--------|
| `components/community.js` | `VerticalLink` now extends `Link` instead of duplicating its styles |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes