### PR TITLE
fix: normalize BitcoLi wallet naming casing

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -501,7 +501,7 @@ const WALLETS = [
     },
   },
   {
-    name: "BitcoLi Wallet",
+    name: "BitcoLi wallet",
     image: "https://bitcoli.com/img/lightningaddress-com/logo.png",
     downloadText: "Download BitcoLi",
     url: "https://bitcoli.com",


### PR DESCRIPTION
## Summary

The BitcoLi wallet entry in `community.js` used "`BitcoLi Wallet`" (uppercase W) while the rest of the codebase uses "`BitcoLi wallet`" (lowercase w):

| Location | Name |
|----------|------|
| `components/providers.js` | `BitcoLi wallet` |
| `components/community.js` | `BitcoLi Wallet` (before fix) |
| `components/footer.js` | `BitcoLi` |
| `README.md` | `BitcoLi wallet` |

This normalizes the community.js entry to match the rest of the site.

## Changes

| File | Change |
|------|--------|
| `components/community.js` | Changed "BitcoLi Wallet" → "BitcoLi wallet" |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes