### PR TITLE
fix: correct copy-paste error in satdress server URLs

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -324,15 +324,15 @@ const SATDRESS_SERVERS = [
     urlText: "@lnaddress.me",
   },
   {
-    urlLink: "https://lnaddress.me/",
+    urlLink: "https://lnaddress.net/",
     urlText: "@lnaddress.net",
   },
   {
-    urlLink: "https://lnaddress.me/",
+    urlLink: "https://lightning.by/",
     urlText: "@lightning.by",
   },
   {
-    urlLink: "https://lnaddress.me/",
+    urlLink: "https://lightning.re/",
     urlText: "@lightning.re",
   },
   {


### PR DESCRIPTION
## Summary

Four entries in the `SATDRESS_SERVERS` array in `components/community.js` all pointed to the same URL (`https://lnaddress.me/`), but only `@lnaddress.me` should use that URL. The remaining three entries (`@lnaddress.net`, `@lightning.by`, `@lightning.re`) had copy-pasted URLs instead of their own domains.

This corrects each entry to link to its own domain, matching the pattern used by all other entries in the array.

| Entry | Before (wrong) | After (fixed) |
|-------|---------------|--------------|
| `@lnaddress.net` | `https://lnaddress.me/` | `https://lnaddress.net/` |
| `@lightning.by` | `https://lnaddress.me/` | `https://lightning.by/` |
| `@lightning.re` | `https://lnaddress.me/` | `https://lightning.re/` |

## Changes

| File | Change |
|------|--------|
| `components/community.js` | Fixed 3 incorrect satdress server URLs |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes — only URL string corrections