### PR TITLE
refactor: remove unused media query breakpoints from utils.js

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -4,12 +4,9 @@ import styled, { css } from 'styled-components';
 // Leverage the `media` function inside the theme
 // to target specific screen sizes.
 
-export const sizes = {
-  mobile: 320,
+const sizes = {
   tablet: 768,
   largeTablet: 920,
-  desktop: 1024,
-  largeDesktop: 1280,
 };
 
 export const media = Object.keys(sizes).reduce((acc, label) => {


### PR DESCRIPTION
## Summary

Three breakpoints in the `sizes` object and generated `media` helper were defined but never used anywhere in the codebase:

| Breakpoint | Defined | Used |
|------------|---------|------|
| `mobile` (320px) | ✅ | ❌ |
| `tablet` (768px) | ✅ | ✅ |
| `largeTablet` (920px) | ✅ | ✅ |
| `desktop` (1024px) | ✅ | ❌ |
| `largeDesktop` (1280px) | ✅ | ❌ |

This removes the three unused breakpoints (`mobile`, `desktop`, `largeDesktop`) and also removes the `export` keyword from `sizes` since no component imports it directly — it is only used internally to build the `media` object.

## Changes

| File | Change |
|------|--------|
| `utils.js` | Removed 3 unused breakpoints; unexported `sizes` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes — unused code removal only

Closes #N/A