### PR TITLE
refactor: remove redundant CSS from hero Title tablet media query

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -32,8 +32,6 @@ const Title = styled.h1`
   ${media.tablet`
     padding: 0 20px;
     font-size: 84px;
-    max-width: 900px;
-    font-weight: 800;
     letter-spacing: -4px;
   `}
 `;


### PR DESCRIPTION
## Summary

`max-width: 900px` and `font-weight: 800` in the `Title` styled component's tablet media query are identical to the base declarations. Removing them eliminates unnecessary CSS without any visual or functional change.

This follows the same cleanup pattern as PR #195 (hero Description) and PR #212 (unused media query breakpoints).

## Changes

| File | Change |
|------|--------|
| `components/hero.js` | Removed redundant `max-width: 900px` and `font-weight: 800` from `Title` tablet media query |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes