### PR TITLE
refactor: remove redundant line-height from hero Intro tablet media query

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -54,7 +54,6 @@ const Intro = styled.p`
   ${media.tablet`
     font-size: 18px;
     max-width: 900px;
-    line-height: 1.6;
   `}
 `;
 


### PR DESCRIPTION
## Summary

`line-height: 1.6` in the `Intro` styled component's tablet media query is identical to the base declaration. Since this is a unitless ratio, it scales correctly with the `font-size: 18px` override in the tablet query. Removing it eliminates unnecessary CSS without any visual or functional change.

This follows the same cleanup pattern as PR #195 (hero Description) and PR #213 (hero Title).

## Changes

| File | Change |
|------|--------|
| `components/hero.js` | Removed redundant `line-height: 1.6` from `Intro` tablet media query |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes