### PR TITLE
chore: add version, author, homepage, and keywords to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,18 @@
 {
   "name": "lightning-address",
-  "description": "lightningaddress.com",
+  "version": "1.0.0",
+  "description": "Like an email address, but for your Bitcoin — an Internet Identifier that allows anyone to send you Bitcoin instantly over the Lightning Network.",
   "private": true,
+  "author": "andrerfneves",
+  "homepage": "https://lightningaddress.com",
+  "keywords": [
+    "lightning",
+    "bitcoin",
+    "lightning-network",
+    "lightning-address",
+    "lnurl",
+    "lnurl-pay"
+  ],
   "scripts": {
     "dev": "next",
     "build": "next build",


### PR DESCRIPTION
## Summary

The package.json was missing several standard metadata fields. This adds:

- **version**: `1.0.0` — initial version for the published site
- **description**: Updated from the minimal `lightningaddress.com` to a meaningful project description
- **author**: `andrerfneves` — repository owner
- **homepage**: `https://lightningaddress.com` — the live site
- **keywords**: Relevant keywords for discoverability: lightning, bitcoin, lightning-network, lightning-address, lnurl, lnurl-pay

These fields are standard for npm packages and are also surfaced on the GitHub repository page.

## Changes

| File | Change |
|------|--------|
| `package.json` | Added `version`, `author`, `homepage`, `keywords`; updated `description` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes