### PR TITLE
refactor: remove redundant color from LicenseLink hover state

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -147,7 +147,6 @@ const LicenseLink = styled.a`
   text-decoration: none;
 
   &:hover {
-    color: #0070f3;
     background: rgba(0,118,255,0.1);
   }
 `;


### PR DESCRIPTION
## Summary

The `LicenseLink` styled component declares `color: #0070f3` in both the base rule and the `&:hover` state. Since the hover color is identical to the base, the hover declaration is redundant and has no visual effect. Removing it eliminates unnecessary CSS.

This follows the same cleanup pattern as PR #196 (BenefitsCard redundant transition), PR #213 (hero Title redundant CSS), and PR #214 (hero Intro redundant line-height).

## Changes

| File | Change |
|------|--------|
| `components/hero.js` | Removed redundant `color: #0070f3` from `LicenseLink` hover state |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes