### PR TITLE
refactor: remove redundant CSS from community Link tablet media query

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -180,9 +180,7 @@ const Link = styled.a`
   background: rgba(0, 118, 255, 0.1);
 
   ${media.tablet`
-    font-size: 14px;
     max-width: 900px;
-    line-height: 1.6;
   `}
 
   &:hover {


### PR DESCRIPTION
## Summary

`font-size: 14px` and `line-height: 1.6` in the `Link` styled component's tablet media query are both identical to the base declarations. Removing them eliminates unnecessary CSS without any visual or functional change.

This follows the same cleanup pattern as PR #195 (hero Description), PR #213 (hero Title), PR #214 (hero Intro), and PR #215 (BenefitsCardImage).

## Changes

| File | Change |
|------|--------|
| `components/community.js` | Removed redundant `font-size: 14px` and `line-height: 1.6` from `Link` tablet media query |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes