### PR TITLE
chore: add repository and bugs fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,13 @@
   "name": "lightning-address",
   "description": "lightningaddress.com",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/andrerfneves/lightning-address.git"
+  },
+  "bugs": {
+    "url": "https://github.com/andrerfneves/lightning-address/issues"
+  },
   "scripts": {
     "dev": "next",
     "build": "next build",


### PR DESCRIPTION
## Summary

The `package.json` was missing standard `repository` and `bugs` metadata fields. These fields are standard for npm packages and are also surfaced on the GitHub repository page.

- `repository`: Points to the canonical Git repository URL
- `bugs`: Points to the GitHub Issues page

## Changes

| File | Change |
|------|--------|
| `package.json` | Added `repository` and `bugs` fields |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes