### PR TITLE
fix: add missing charset meta tag to _document.js

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -31,7 +31,9 @@ export default class MyDocument extends Document {
   render() {
     return (
       <Html lang="en">
-        <Head />
+        <Head>
+          <meta charSet="utf-8" />
+        </Head>
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
## Summary

A custom Next.js `_document.js` overrides the default document template, and the `<meta charSet="utf-8" />` tag is not auto-included. Adding it explicitly ensures proper character encoding declaration in the rendered HTML, which is a standard HTML5 best practice.

## Changes

| File | Change |
|------|--------|
| `pages/_document.js` | Added `<meta charSet="utf-8" />` inside `<Head>` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes