### PR TITLE
fix: normalize CoinCorner, NOAH, and LN Markets brand name casing in providers section

### DIFF
--- a/components/providers.js
+++ b/components/providers.js
@@ -207,7 +207,7 @@ const PROVIDERS = [
     url: "https://bitrefill.com/",
   },
   {
-    name: "LNMarkets",
+    name: "LN Markets",
     image: "/images/lnmarkets.png",
     imageStyle: { width: "125px" },
     lightningAddressDomain: "lnmarkets.com",
@@ -223,7 +223,7 @@ const PROVIDERS = [
     buttonText: "Download Strike",
   },
   {
-    name: "Coincorner",
+    name: "CoinCorner",
     image: "/images/coincorner.svg",
     imageStyle: { width: "130px" },
     lightningAddressDomain: "coincorner.io",
@@ -283,7 +283,7 @@ const PROVIDERS = [
     buttonText: "Download Wallet",
   },
   {
-    name: "Noah",
+    name: "NOAH",
     image: "/images/noah.png",
     imageStyle: { width: "115px" },
     lightningAddressDomain: "noah.me",


### PR DESCRIPTION
## Summary

Three brand name casing fixes in the providers directory that were inconsistent with the official brand names and the README:

| Provider | Before | After | README entry |
|----------|--------|-------|-------------|
| CoinCorner | `Coincorner` | `CoinCorner` | `CoinCorner` |
| NOAH | `Noah` | `NOAH` | `NOAH` |
| LN Markets | `LNMarkets` | `LN Markets` | `LN Markets` |

This follows the same data consistency pattern as PR #210 (merged, "fix: normalize BitcoLi wallet naming casing") and PR #219 ("fix: normalize coinos wallet naming casing in footer").

## Changes

| File | Change |
|------|--------|
| `components/providers.js` | Fixed 3 brand name casing inconsistencies |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes