### PR TITLE
fix: normalize LNbits wallet name casing

### DIFF
--- a/BRIDGE.md
+++ b/BRIDGE.md
@@ -11,7 +11,7 @@ The [`bridgeaddr`](https://github.com/fiatjaf/bridgeaddr) server tool is a simpl
 * Sparko
 * LND
 * LNPay
-* LNBits
+* LNbits
 
 This server will serve the necessary JSON and then use RPC calls to connect to your node and fetch invoices on demand. You don't have to do anything besides buying a domain and setting up some DNS records. HTTPS will be provided automatically for you.
 

--- a/components/community.js
+++ b/components/community.js
@@ -408,9 +408,9 @@ const WALLETS = [
     url: "https://phoenix.acinq.co/",
   },
   {
-    name: "LNBits",
+    name: "LNbits",
     image: "/images/lnbits.png",
-    downloadText: "Open LNBits",
+    downloadText: "Open LNbits",
     url: "https://lnbits.com/",
   },
   {

--- a/components/footer.js
+++ b/components/footer.js
@@ -62,7 +62,7 @@ const FOOTER = [
       },
       {
         link: "https://lnbits.com",
-        title: "LNBits",
+        title: "LNbits",
       },
       {
         link: "https://getalby.com",


### PR DESCRIPTION
## Summary

The community section, footer, and BRIDGE docs referred to the wallet as `LNBits` (uppercase B), but the official brand name uses lowercase `b` — `LNbits` — matching the project's own branding at lnbits.org and the README.

## Changes

| File | Change |
|------|--------|
| `components/community.js` | Changed `LNBits` → `LNbits` in wallet name and download button text |
| `components/footer.js` | Changed `LNBits` → `LNbits` in Sending section title |
| `BRIDGE.md` | Changed `LNBits` → `LNbits` in bridge server list |

This follows the same data consistency pattern as PR #210 (BitcoLi), PR #219 (coinos), and #223 (CoinCorner/NOAH/LN Markets).

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes