### PR TITLE
fix: update Mash URL in footer to match providers and community sections

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -154,7 +154,7 @@ const FOOTER = [
         title: "LN Markets",
       },
       {
-        link: "https://getmash.com",
+        link: "https://mash.com/consumer-experience/",
         title: "Mash",
       },
       {


### PR DESCRIPTION
## Summary

The footer's "Receiving" section linked to `getmash.com` for Mash, but `providers.js` and `community.js` both use `mash.com/consumer-experience/` as the canonical URL. This updates the footer to use the same URL for consistency.

This follows the same data consistency pattern as PR #211 (merged, "fix: correct copy-paste error in satdress server URLs").

## Changes

| File | Change |
|------|--------|
| `components/footer.js` | Changed `https://getmash.com` → `https://mash.com/consumer-experience/` in the Receiving section |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes