### PR TITLE
fix: update Mash URL in README to match providers and community sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ _Bitcoin Lightning wallets that support sending and receiving to **Lightning Add
 | [LNbits](https://lnbits.org/)                                     | ☑️        | WIP       |
 | [@lntxbot](https://lntxbot.com/)                                  | ☑️        | ☑️        |
 | [Machankura](https://8333.mobi/)                                  | ☑️        | ☑️        |
-| [Mash](https://getmash.com/)                                      | ----      | ☑️        |
+| [Mash](https://mash.com/consumer-experience/)                     | ----      | ☑️        |
 | [Muun](https://muun.com/)                                         | ----      | ----      |
 | [NOAH](https://app.noah.com/)                                     | ☑️        | ☑️        |
 | [NiceHash](https://nicehash.com/)                                 | ----      | ☑️        |


### PR DESCRIPTION
## Summary

The README's wallet table linked to `getmash.com` for Mash, but `providers.js` and `community.js` both use `mash.com/consumer-experience/` as the canonical URL. This updates the README to use the same URL for consistency.

This follows the same data consistency pattern as PR #225 (open, "fix: update Mash URL in footer to match providers and community sections").

## Changes

| File | Change |
|------|--------|
| `README.md` | Changed `https://getmash.com` → `https://mash.com/consumer-experience/` in the wallet table |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes