### PR TITLE
fix: remove defunct Bottlepay wallet from README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ _Bitcoin Lightning wallets that support sending and receiving to **Lightning Add
 | [Blixt](https://blixtwallet.github.io/)                           | ☑️        | [WIP](https://github.com/hsjoberg/lightning-box/blob/master/README.md)     |
 | [BlueWallet](https://bluewallet.io/)                              | ☑️        | ----      |
 | [Bookmark.org](https://bookmark.org/)                             | ----      | ☑️        |
-| [Bottlepay](https://bottlepay.com/)                               | ☑️        | ☑️        |
 | [Breez](https://breez.technology/)                                | ☑️        | ----      |
 | [BTCPay](https://btcpayserver.org/)                               | ☑️        | ☑️        |
 | [Cash App](https://cash.app/)                                     | ☑️        | ☑️        |


### PR DESCRIPTION
## Summary

Bottlepay shut down in 2023 and is no longer operational. The README still listed it as a supported wallet with both sending and receiving capabilities. Removing it prevents user confusion.

This cleanup was missed by earlier data-consistency PRs (PR #198, #199, #210).

## Changes

| File | Change |
|------|--------|
| `README.md` | Removed the Bottlepay row from the wallet table |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes