### PR TITLE
chore: add engines field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "lightning-address",
   "description": "lightningaddress.com",
   "private": true,
+  "engines": {
+    "node": ">=18.18.0"
+  },
   "scripts": {
     "dev": "next",
     "build": "next build",


### PR DESCRIPTION
## Summary

Adds the `engines` field to `package.json` to document the minimum required Node.js version (`>=18.18.0`) for Next.js 16 compatibility. Package managers like npm, yarn, and pnpm will display a warning when a user attempts to run the project with an incompatible Node.js version.

This complements the `.nvmrc` file being added in PR #221 — the `engines` field works with npm/yarn/pnpm native checks, while `.nvmrc` works with nvm/fnm/volta.

## Changes

| File | Change |
|------|--------|
| `package.json` | Added `engines` field with `node: ">=18.18.0"` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes