### PR TITLE
fix: normalize BitcoLi wallet image URL across providers and community sections

### DIFF
--- a/components/providers.js
+++ b/components/providers.js
@@ -338,7 +338,7 @@ const PROVIDERS = [
   },
   {
     name: "BitcoLi wallet",
-    image: "https://bitcoli.com/img/logo-40.png",
+    image: "https://bitcoli.com/img/lightningaddress-com/logo.png",
     imageStyle: { width: "45px", backgroundColor: "black", borderRadius: "5%" },
     lightningAddressDomain: "bitcoli.com",
     url: "https://bitcoli.com",


### PR DESCRIPTION
## Summary

The `providers.js` used `https://bitcoli.com/img/logo-40.png` while `community.js` used `https://bitcoli.com/img/lightningaddress-com/logo.png` for the same wallet. This normalizes both to use the lightningaddress-com branded logo that matches the site context.

## Changes

| File | Change |
|------|--------|
| `components/providers.js` | Changed BitcoLi image URL from `https://bitcoli.com/img/logo-40.png` to `https://bitcoli.com/img/lightningaddress-com/logo.png` (matching `community.js`) |

## Test Plan

- [ ] Build passes clean (`npm run build`)
- [ ] No functional or visual changes