### PR TITLE
refactor: remove dead code fallback in benefits.js map

### DIFF
--- a/components/benefits.js
+++ b/components/benefits.js
@@ -171,7 +171,7 @@ export const Benefits = () => (
     <BenefitsTitle>Why do I need a Lightning Address?</BenefitsTitle>
     <BenefitsDescription>We created the Lightning Address protocol to empower everyone to send money like we send emails — instantly and abundantly. Coupled with the Lightning Network’s ability to send Bitcoin instantly and with (almost) no fees, we’re ushering in a new standard for how value moves around the world.</BenefitsDescription>
     <BenefitsCardGrid>
-      {(BENEFITS || []).map((benefit) => (
+      {BENEFITS.map((benefit) => (
         <BenefitsCard key={benefit.title}>
           <BenefitsCardImage src={benefit.image} alt={benefit.title} />
           <BenefitsCardTitle>


### PR DESCRIPTION
## Summary

The `BENEFITS` constant is defined inline in the same file, so the `|| []` fallback in the `.map()` call can never trigger. Removing it cleans up the code and matches the same fix already applied to `paths.js` (PR #194) and `footer.js`.

## Changes

| File | Change |
|------|--------|
| `components/benefits.js` | Removed the `|| []` dead code fallback from the `.map()` call | 

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes