### PR TITLE
fix: add og:image:width and og:image:height meta tags for social sharing

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -38,6 +38,8 @@ export default function Home() {
           content="Like an email address, but for your Bitcoin. An Internet Identifier that allows anyone to send you Bitcoin instantly over the Lightning Network. No scanning QR codes or pasting invoices."
         />
         <meta property="og:image" content="https://i.imgur.com/wL4cC1t.png" />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
 
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@andreneves" />


### PR DESCRIPTION
## Summary

The `og:image` meta tag was present but lacked the `og:image:width` and `og:image:height` dimension hints. These tags help social media platforms (Facebook, Twitter, LinkedIn) render the preview image correctly without layout shifts before the image loads.

Using the standard recommended OG image dimensions of 1200×630 pixels (1.91:1 aspect ratio).

## Changes

| File | Change |
|------|--------|
| `pages/index.js` | Added `og:image:width` (1200) and `og:image:height` (630) meta tags after `og:image` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes