### PR TITLE
fix: update stale master branch references to main

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -559,7 +559,7 @@ export const Community = () => (
         ))}
         <CTAWrapper>
           <CTASecondary
-            href="https://github.com/andrerfneves/lightning-address/blob/master/README.md#wallets-supported"
+            href="https://github.com/andrerfneves/lightning-address/blob/main/README.md#wallets-supported"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/components/footer.js
+++ b/components/footer.js
@@ -12,7 +12,7 @@ const FOOTER = [
     title: "Resources",
     items: [
       {
-        link: "https://github.com/andrerfneves/lightning-address/blob/master/README.md",
+        link: "https://github.com/andrerfneves/lightning-address/blob/main/README.md",
         title: "Dev Documentation",
       },
       {

--- a/components/hero.js
+++ b/components/hero.js
@@ -261,11 +261,11 @@ export function Hero() {
         >
           <CTAWrapper>
             <CTAPrimary href="#providers">Get a Lightning Address</CTAPrimary>
-            <CTASecondary href="https://github.com/andrerfneves/lightning-address/blob/master/README.md" target="_blank" rel="noopener noreferrer">Read Documentation</CTASecondary>
+            <CTASecondary href="https://github.com/andrerfneves/lightning-address/blob/main/README.md" target="_blank" rel="noopener noreferrer">Read Documentation</CTASecondary>
           </CTAWrapper>
           <LicenseWrapper>
             <LicenseText>License: MIT</LicenseText>
-            <LicenseLink href='https://github.com/andrerfneves/lightning-address/blob/master/LICENSE.md' target='_blank' rel="noopener noreferrer">GitHub</LicenseLink>
+            <LicenseLink href='https://github.com/andrerfneves/lightning-address/blob/main/LICENSE.md' target='_blank' rel="noopener noreferrer">GitHub</LicenseLink>
           </LicenseWrapper>
         </HeroSection>
       )}

--- a/components/paths.js
+++ b/components/paths.js
@@ -158,7 +158,7 @@ const IMPLEMENTATIONS = [
     description: 'Lightning Address is just a set of simple protocol instructions. Whether you are a Bitcoin service provider or simply an enthusiast interested in running your own setup, this is where you get started supporting this new standard.',
     image: '/images/data2.svg',
     linkText: 'Learn More',
-    link: 'https://github.com/andrerfneves/lightning-address/blob/master/DIY.md',
+    link: 'https://github.com/andrerfneves/lightning-address/blob/main/DIY.md',
     isSecondary: true,
     isInternal: false,
   },


### PR DESCRIPTION
## Summary

The repo's default branch was renamed from `master` to `main`, but several components still referenced `blob/master/...` URLs for this repository. This updates all remaining stale `master` references to `main`.

## Changes

| File | Change |
|------|--------|
| `components/hero.js` | Two URLs: Read Documentation link and GitHub license link |
| `components/footer.js` | Dev Documentation URL in Resources column |
| `components/paths.js` | DIY.md URL in Self-Hosted card |
| `components/community.js` | View list of supported Wallets link |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes