### PR TITLE
refactor: remove redundant transition from PathsCard hover in paths.js

### DIFF
--- a/components/paths.js
+++ b/components/paths.js
@@ -69,7 +69,6 @@ const PathsCard = styled.div`
 
   &:hover {
     border: 1px solid #ccc;
-    transition: box-shadow .2s ease;
     box-shadow: 0 8px 30px rgba(0,0,0,0.12);
   }
 


### PR DESCRIPTION
## Summary

The `PathsCard` styled component already defines `transition: box-shadow .2s ease` on the base element, so repeating it in the `:hover` block is redundant. Removing it cleans up the CSS and matches the same fix already applied to `BenefitsCard` in PR #196.

## Changes

| File | Change |
|------|--------|
| `components/paths.js` | Removed redundant `transition: box-shadow .2s ease` from `PathsCard:hover` | 

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes