### PR TITLE
refactor: remove redundant CSS from CommunityListWrapper tablet media query

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -145,8 +145,6 @@ const CommunityListWrapper = styled.div`
   justify-content: center;
 
   ${media.tablet`
-    flex-wrap: wrap;
-    flex-direction: row;
     justify-content: flex-start;
   `}
 `;


### PR DESCRIPTION
## Summary

The `CommunityListWrapper` styled component in `community.js` repeats `flex-wrap: wrap` and `flex-direction: row` in the tablet media query, but these properties are already set with the same values on the base component. Only `justify-content` actually changes (from `center` to `flex-start`) on tablet, so only that property needs to be in the media query.

## Changes

| File | Change |
|------|--------|
| `components/community.js` | Removed redundant `flex-wrap: wrap` and `flex-direction: row` from `CommunityListWrapper` tablet media query | 

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes