### PR TITLE
refactor: remove redundant transition from BenefitsCard hover in benefits.js

### DIFF
--- a/components/benefits.js
+++ b/components/benefits.js
@@ -80,7 +80,6 @@ const BenefitsCard = styled.div`
 
   &:hover {
     border: 1px solid #ccc;
-    transition: box-shadow .2s ease;
     box-shadow: 0 8px 30px rgba(0,0,0,0.12);
   }
 `;


### PR DESCRIPTION
## Summary

The `BenefitsCard` styled component already defines `transition: box-shadow .2s ease` on the base element, so repeating it in the `:hover` block is redundant. Removing it cleans up the CSS and matches the same fix already applied to `PathsCard` in PR #234.

## Changes

| File | Change |
|------|--------|
| `components/benefits.js` | Removed redundant `transition: box-shadow .2s ease` from `BenefitsCard:hover` | 

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes