### PR TITLE
refactor: remove redundant CSS from hero Description tablet media query

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -76,11 +76,8 @@ const Description = styled.p`
   margin: 20px auto 0 auto;
 
   ${media.tablet`
-    padding: 0;
     font-size: 20px;
-    padding: 0 30px;
     max-width: 500px;
-    line-height: 1.4;
     letter-spacing: -1px;
   `}
 `;


### PR DESCRIPTION
## Summary

The `Description` styled component in `hero.js` had three redundant declarations in the tablet media query:

- `padding: 0` — immediately overridden by the following `padding: 0 30px` line
- `padding: 0 30px` — already set with the same value in the base element
- `line-height: 1.4` — already set with the same value in the base element

Only `font-size: 20px`, `max-width: 500px`, and `letter-spacing: -1px` actually change on tablet, so only those properties remain in the media query.

## Changes

| File | Change |
|------|--------|
| `components/hero.js` | Removed redundant `padding: 0`, `padding: 0 30px`, and `line-height: 1.4` from `Description` tablet media query |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes