### PR TITLE
refactor: remove dead code fallbacks in footer.js map calls

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -304,10 +304,10 @@ export const Footer = () => (
   <Wrapper>
     <InnerWrapper>
       <Menus>
-        {(FOOTER || []).map((col) => (
+        {FOOTER.map((col) => (
           <Column key={col.title}>
             <ColumnTitle>{col.title}</ColumnTitle>
-            {(col.items || []).map((item) => (
+            {col.items.map((item) => (
               <ColumnItem key={item.link} href={item.link} target="_blank" rel="noopener noreferrer">
                 {item.title}
               </ColumnItem>


### PR DESCRIPTION
## Summary

The `FOOTER` constant is defined inline in the same file, so the `|| []` fallback in `(FOOTER || []).map()` can never trigger. Similarly, each `FOOTER` entry has an `items` array, so `(col.items || []).map()` is also dead code.

This follows the same cleanup pattern applied to `benefits.js` (PR #231).

## Changes

| File | Change |
|------|--------|
| `components/footer.js` | Removed ``|| []`` from both `FOOTER.map()` and `col.items.map()` calls |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes