### PR TITLE
fix: normalize Satoshi Lightning wallet name in community section

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -444,9 +444,9 @@ const WALLETS = [
     },
   },
   {
-    name: "Satoshi Wallet",
+    name: "Satoshi Lightning",
     image: "https://vipsats.app/img/satoshi.png",
-    downloadText: "Download Satoshi",
+    downloadText: "Download Satoshi Lightning",
     url: "https://vipsats.app",
     imageStyle: {
       width: "45px",


### PR DESCRIPTION
## Summary

The community section's wallet list referred to the `vipsats.app` provider as `Satoshi Wallet` with download text `Download Satoshi`. However, all other references across the codebase — README, footer (both sending and receiving sections), and providers section — use `Satoshi Lightning`. This normalizes the community section to match.

## Changes

| File | Change |
|------|--------|
| `components/community.js` | Changed `name: "Satoshi Wallet"` → `name: "Satoshi Lightning"` and `downloadText: "Download Satoshi"` → `downloadText: "Download Satoshi Lightning"` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes