### PR TITLE
feat: add canonical URL meta tag for SEO

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -38,6 +38,7 @@ export default function Home() {
           content="Like an email address, but for your Bitcoin. An Internet Identifier that allows anyone to send you Bitcoin instantly over the Lightning Network. No scanning QR codes or pasting invoices."
         />
         <meta property="og:image" content="https://i.imgur.com/wL4cC1t.png" />
+        <link rel="canonical" href="https://lightningaddress.com" />
 
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@andreneves" />


### PR DESCRIPTION
## Summary

The page `<Head>` was missing a `<link rel="canonical">` tag. Adding one helps search engines identify the preferred URL for the site and avoid duplicate content issues (e.g., `www.` vs non-`www.`, trailing slash variations, etc.).

## Changes

| File | Change |
|------|--------|
| `pages/index.js` | Added `<link rel="canonical" href="https://lightningaddress.com" />` after `og:image` meta tag |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes