### PR TITLE
refactor: remove dead code fallback in paths.js map call

### DIFF
--- a/components/paths.js
+++ b/components/paths.js
@@ -172,7 +172,7 @@ export const Paths = () => (
       We’ve made it exceedingly straightforward to start supporting Lightning Addresses on your own domain or integrate them with the apps you’re building. Set up support for this new standard today and join the era of total Lightning interoperability!
     </PathsDescription>
     <PathsCardGrid>
-      {(IMPLEMENTATIONS || []).map((benefit) => (
+      {IMPLEMENTATIONS.map((benefit) => (
         <PathsCard key={benefit.title}>
           <PathsCardImage src={benefit.image} alt={benefit.title} />
           <PathsCardTitle>


### PR DESCRIPTION
## Summary

The `IMPLEMENTATIONS` constant is defined inline in the same file, so the `|| []` fallback in the `.map()` call can never trigger. Removing it cleans up dead code.

This follows the same cleanup pattern applied to:
- `benefits.js` (PR #231)
- `footer.js` (PR #238)

## Changes

| File | Change |
|------|--------|
| `components/paths.js` | Removed `|| []` from `IMPLEMENTATIONS.map()` call |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes