### PR TITLE
refactor: extract shared ImageWrapper styled component

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media, CTASecondary as BaseCTASecondary, SectionBase, SectionLeft, SectionRight, SectionRightInner } from "../utils";
+import { media, CTASecondary as BaseCTASecondary, SectionBase, SectionLeft, SectionRight, SectionRightInner, ImageWrapper } from "../utils";
 
 const CommunityModule = styled(SectionBase)`
   background: #fff;
@@ -123,18 +123,6 @@ const CommunitySignUpButton = styled.a`
 const Image = styled.img`
   width: 130px;
   align-self: center;
-`;
-
-const ImageWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  justify-content: center;
-  flex: 1;
-
-  ${media.tablet`
-    padding-right: 15px;
-  `}
 `;
 
 const CommunityListWrapper = styled.div`

--- a/components/providers.js
+++ b/components/providers.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media, SectionBase, SectionLeft, SectionRight, SectionRightInner } from "../utils";
+import { media, SectionBase, SectionLeft, SectionRight, SectionRightInner, ImageWrapper } from "../utils";
 
 const ProvidersModule = styled(SectionBase)`
   background: #fafafa;
@@ -161,18 +161,6 @@ const ProviderSignUpButton = styled.a`
   ${media.tablet`
     min-width: 220px;
     margin: 0 15px 0 0;
-  `}
-`;
-
-const ImageWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  justify-content: center;
-  flex: 1;
-
-  ${media.tablet`
-    padding-right: 15px;
   `}
 `;
 

--- a/utils.js
+++ b/utils.js
@@ -78,6 +78,18 @@ export const CTAPrimary = styled.a`
   `}
 `;
 
+export const ImageWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  flex: 1;
+
+  ${media.tablet`
+    padding-right: 15px;
+  `}
+`;
+
 export const CTASecondary = styled.a`
   color: #696969;
   cursor: pointer;


### PR DESCRIPTION
## Summary

The `ImageWrapper` styled component was defined identically in both `community.js` and `providers.js`. This extracts it to `utils.js` as a shared component.

This follows the same cleanup pattern established in prior PRs:
- PR #181 — shared `CTASecondary`
- PR #206 — shared `SectionDescription`
- PR #205 — shared `SectionTitle`

## Changes

| File | Change |
|------|--------|
| `utils.js` | Added shared `ImageWrapper` styled component |
| `components/community.js` | Import shared `ImageWrapper`; removed local definition |
| `components/providers.js` | Import shared `ImageWrapper`; removed local definition |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes