### PR TITLE
refactor: extract shared Card styled component

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media, CTASecondary as BaseCTASecondary, SectionBase, SectionLeft, SectionRight, SectionRightInner } from "../utils";
+import { media, CTASecondary as BaseCTASecondary, SectionBase, SectionLeft, SectionRight, SectionRightInner, Card } from "../utils";
 
 const CommunityModule = styled(SectionBase)`
   background: #fff;
@@ -69,28 +69,6 @@ const CommunityInner = styled.div`
     margin-top: 80px;
     max-width: 1000px;
     flex-direction: row;
-  `}
-`;
-
-const CommunityCard = styled.div`
-  margin: 20px auto 20px auto;
-  display: flex;
-  padding: 16px;
-  min-height: 100px;
-  border-radius: 6px;
-  align-items: center;
-  flex-direction: column;
-  background-color: #fff;
-  justify-content: center;
-  box-shadow: 0px 30px 60px rgb(0 0 0 / 12%);
-
-  ${media.tablet`
-    width: 425px;
-    height: 42px;
-    margin: 20px 0;
-    min-height: auto;
-    flex-direction: row;
-    justify-content: space-between;
   `}
 `;
 
@@ -544,7 +522,7 @@ export const Community = () => (
           easily as you send emails.
         </CommunityDescriptionSmall>
         {WALLETS.map((wallet) => (
-          <CommunityCard key={wallet.name}>
+          <Card key={wallet.name}>
             <ImageWrapper>
               <Image
                 src={wallet.image}
@@ -555,7 +533,7 @@ export const Community = () => (
             <CommunitySignUpButton target="_blank" rel="noopener noreferrer" href={wallet.url}>
               {wallet.downloadText}
             </CommunitySignUpButton>
-          </CommunityCard>
+          </Card>
         ))}
         <CTAWrapper>
           <CTASecondary

--- a/components/providers.js
+++ b/components/providers.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media, SectionBase, SectionLeft, SectionRight, SectionRightInner } from "../utils";
+import { media, SectionBase, SectionLeft, SectionRight, SectionRightInner, Card } from "../utils";
 
 const ProvidersModule = styled(SectionBase)`
   background: #fafafa;
@@ -111,28 +111,6 @@ const ProvidersEmailButtonText = styled.span`
   ${media.tablet`
     padding-top: 0;
     padding-left: 0;
-  `}
-`;
-
-const ProviderCard = styled.div`
-  margin: 20px auto 20px auto;
-  display: flex;
-  padding: 16px;
-  min-height: 100px;
-  border-radius: 6px;
-  align-items: center;
-  flex-direction: column;
-  background-color: #fff;
-  justify-content: center;
-  box-shadow: 0px 30px 60px rgb(0 0 0 / 12%);
-
-  ${media.tablet`
-    width: 425px;
-    height: 42px;
-    margin: 20px 0;
-    min-height: auto;
-    flex-direction: row;
-    justify-content: space-between;
   `}
 `;
 
@@ -425,7 +403,7 @@ export const Providers = () => (
           services that already support it. You’ll be set up in seconds!
         </ProvidersDescription>
         {PROVIDERS.map((provider) => (
-          <ProviderCard key={provider.name}>
+          <Card key={provider.name}>
             <ImageWrapper>
               <img
                 src={provider.image}
@@ -442,7 +420,7 @@ export const Providers = () => (
             >
               {provider.buttonText || `Open ${provider.name}`}
             </ProviderSignUpButton>
-          </ProviderCard>
+          </Card>
         ))}
       </SectionLeft>
       <SectionRight>

--- a/utils.js
+++ b/utils.js
@@ -101,3 +101,25 @@ export const CTASecondary = styled.a`
     margin: 0 0 0 15px;
   `}
 `;
+
+export const Card = styled.div`
+  margin: 20px auto 20px auto;
+  display: flex;
+  padding: 16px;
+  min-height: 100px;
+  border-radius: 6px;
+  align-items: center;
+  flex-direction: column;
+  background-color: #fff;
+  justify-content: center;
+  box-shadow: 0px 30px 60px rgb(0 0 0 / 12%);
+
+  ${media.tablet`
+    width: 425px;
+    height: 42px;
+    margin: 20px 0;
+    min-height: auto;
+    flex-direction: row;
+    justify-content: space-between;
+  `}
+`;


### PR DESCRIPTION
## Summary

The `ProviderCard` (in `providers.js`) and `CommunityCard` (in `community.js`) styled components were identical — same margin, padding, border-radius, box-shadow, background, flex layout, and responsive breakpoint. This extracts them to `utils.js` as a shared `Card` component.

This follows the same cleanup pattern established in prior PRs:
- PR #205 — shared `SectionTitle`
- PR #206 — shared `SectionDescription`
- PR #242 — shared `ImageWrapper`

## Changes

| File | Change |
|------|--------|
| `utils.js` | Added shared `Card` styled component |
| `components/providers.js` | Import shared `Card`; removed local `ProviderCard` |
| `components/community.js` | Import shared `Card`; removed local `CommunityCard` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes