### PR TITLE
fix: normalize Blixt wallet URL in footer to match README

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -49,7 +49,7 @@ const FOOTER = [
         title: "BlueWallet",
       },
       {
-        link: "https://blixtwallet.com/",
+        link: "https://blixtwallet.github.io/",
         title: "Blixt Wallet",
       },
       {


### PR DESCRIPTION
## Summary

The footer's Sending section linked to `https://blixtwallet.com/` for the Blixt wallet, but this domain redirects to the canonical GitHub Pages URL `https://blixtwallet.github.io/`. The README already uses the canonical URL, so this updates the footer to match.

## Changes

| File | Change |
|------|--------|
| `components/footer.js` | Changed `https://blixtwallet.com/` → `https://blixtwallet.github.io/` in the Sending section |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes