### PR TITLE
fix: add twitter:image:alt meta tag for accessibility

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -48,6 +48,7 @@ export default function Home() {
           content="Like an email address, but for your Bitcoin. A massively simpler way for anyone to send you Bitcoin instantly on the Lightning Network. No scanning QR codes or pasting invoices."
         />
         <meta name="twitter:image" content="https://i.imgur.com/wL4cC1t.png" />
+        <meta name="twitter:image:alt" content="The Lightning Address — Send and receive Bitcoin like you do emails" />
 
         <script
           defer


### PR DESCRIPTION
## Summary

The Twitter card meta tags included `twitter:image` but were missing the `twitter:image:alt` attribute. This alt text is used by screen readers and assistive technologies to describe the shared image when the page is posted on Twitter/X.

## Changes

| File | Change |
|------|--------|
| `pages/index.js` | Added `<meta name=\twitter:image:alt\>` after the `twitter:image` meta tag |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes