### PR TITLE
refactor: extract shared SectionTitle styled component

### DIFF
--- a/components/benefits.js
+++ b/components/benefits.js
@@ -1,27 +1,10 @@
 import styled from 'styled-components';
 
-import { media, CTAPrimary, SectionBase } from '../utils';
+import { media, CTAPrimary, SectionBase, SectionTitle } from '../utils';
 
 const BenefitsModule = styled(SectionBase)`
   background: #fafafa;
   border-bottom: 1px solid #eaeaea;
-`;
-
-const BenefitsTitle = styled.div`
-  margin: 0 auto;
-  font-size: 30px;
-  padding: 0 30px;
-  max-width: 500px;
-  font-weight: 800;
-  line-height: 1.3;
-  text-align: center;
-  letter-spacing: -0.5px;
-
-  ${media.tablet`
-    padding: 0;
-    font-size: 44px;
-    letter-spacing: -1px;
-  `}
 `;
 
 const BenefitsDescription = styled.div`
@@ -168,7 +151,7 @@ const BENEFITS = [
 export const Benefits = () => (
   <BenefitsModule>
     <BenefitsIntro>Users & Enthusiasts</BenefitsIntro>
-    <BenefitsTitle>Why do I need a Lightning Address?</BenefitsTitle>
+    <SectionTitle>Why do I need a Lightning Address?</SectionTitle>
     <BenefitsDescription>We created the Lightning Address protocol to empower everyone to send money like we send emails — instantly and abundantly. Coupled with the Lightning Network’s ability to send Bitcoin instantly and with (almost) no fees, we’re ushering in a new standard for how value moves around the world.</BenefitsDescription>
     <BenefitsCardGrid>
       {(BENEFITS || []).map((benefit) => (

--- a/components/community.js
+++ b/components/community.js
@@ -1,27 +1,10 @@
 import styled from "styled-components";
 
-import { media, CTASecondary as BaseCTASecondary, SectionBase, SectionLeft, SectionRight, SectionRightInner } from "../utils";
+import { media, CTASecondary as BaseCTASecondary, SectionBase, SectionLeft, SectionRight, SectionRightInner, SectionTitle } from "../utils";
 
 const CommunityModule = styled(SectionBase)`
   background: #fff;
   border-top: 1px solid #eaeaea;
-`;
-
-const CommunityTitle = styled.div`
-  margin: 0 auto;
-  font-size: 30px;
-  padding: 0 30px;
-  max-width: 500px;
-  font-weight: 800;
-  line-height: 1.3;
-  text-align: center;
-  letter-spacing: -0.5px;
-
-  ${media.tablet`
-    padding: 0;
-    font-size: 44px;
-    letter-spacing: -1px;
-  `}
 `;
 
 const CommunityDescription = styled.div`
@@ -526,7 +509,7 @@ const WALLETS = [
 export const Community = () => (
   <CommunityModule id="community">
     <CommunityIntro>Community Efforts & Tools</CommunityIntro>
-    <CommunityTitle>Noncustodial Bridge Servers</CommunityTitle>
+    <SectionTitle>Noncustodial Bridge Servers</SectionTitle>
     <CommunityDescription>
       The Lightning Address standard continues to be adopted by community
       participants and companies in the industry. From mobile and desktop wallet

--- a/components/paths.js
+++ b/components/paths.js
@@ -1,26 +1,9 @@
 import styled from 'styled-components';
 
-import { media, SectionBase } from '../utils';
+import { media, SectionBase, SectionTitle } from '../utils';
 
 const PathsModule = styled(SectionBase)`
   background: #fff;
-`;
-
-const PathsTitle = styled.div`
-  margin: 0 auto;
-  font-size: 30px;
-  padding: 0 30px;
-  max-width: 500px;
-  font-weight: 800;
-  line-height: 1.3;
-  text-align: center;
-  letter-spacing: -0.5px;
-
-  ${media.tablet`
-    padding: 0;
-    font-size: 44px;
-    letter-spacing: -1px;
-  `}
 `;
 
 const PathsDescription = styled.div`
@@ -167,7 +150,7 @@ const IMPLEMENTATIONS = [
 export const Paths = () => (
   <PathsModule>
     <PathsIntro>Developers & Shadowy Coders</PathsIntro>
-    <PathsTitle>Integrates as fast as Lightning</PathsTitle>
+    <SectionTitle>Integrates as fast as Lightning</SectionTitle>
     <PathsDescription>
       We’ve made it exceedingly straightforward to start supporting Lightning Addresses on your own domain or integrate them with the apps you’re building. Set up support for this new standard today and join the era of total Lightning interoperability!
     </PathsDescription>

--- a/utils.js
+++ b/utils.js
@@ -101,3 +101,20 @@ export const CTASecondary = styled.a`
     margin: 0 0 0 15px;
   `}
 `;
+
+export const SectionTitle = styled.div`
+  margin: 0 auto;
+  font-size: 30px;
+  padding: 0 30px;
+  max-width: 500px;
+  font-weight: 800;
+  line-height: 1.3;
+  text-align: center;
+  letter-spacing: -0.5px;
+
+  ${media.tablet`
+    padding: 0;
+    font-size: 44px;
+    letter-spacing: -1px;
+  `}
+`;


### PR DESCRIPTION
## Summary

`BenefitsTitle` (in `benefits.js`), `PathsTitle` (in `paths.js`), and `CommunityTitle` (in `community.js`) were identical styled components — same margin, padding, font-size, font-weight, text-align, and responsive breakpoint. This extracts them to `utils.js` as a shared `SectionTitle` component.

This follows the same cleanup pattern established in prior PRs:
- PR #208 — shared `SectionBase`
- PR #242 — shared `ImageWrapper`
- PR #243 — shared `Card`

## Changes

| File | Change |
|------|--------|
| `utils.js` | Added shared `SectionTitle` styled component |
| `components/benefits.js` | Import shared `SectionTitle`; removed local `BenefitsTitle` |
| `components/paths.js` | Import shared `SectionTitle`; removed local `PathsTitle` |
| `components/community.js` | Import shared `SectionTitle`; removed local `CommunityTitle` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes