### PR TITLE
refactor: extract shared SectionDescription styled component

### DIFF
--- a/components/benefits.js
+++ b/components/benefits.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { media, CTAPrimary, SectionBase } from '../utils';
+import { media, CTAPrimary, SectionBase, SectionDescription } from '../utils';
 
 const BenefitsModule = styled(SectionBase)`
   background: #fafafa;
@@ -24,20 +24,9 @@ const BenefitsTitle = styled.div`
   `}
 `;
 
-const BenefitsDescription = styled.div`
-  color: #666666;
-  padding: 0 30px;
-  font-size: 16px;
-  line-height: 1.4;
-  font-weight: 400;
-  max-width: 800px;
-  text-align: center;
-  letter-spacing: -1px;
-  margin: 20px auto 0 auto;
-
+const BenefitsDescription = styled(SectionDescription)`
   ${media.tablet`
-    font-size: 20px;
-    line-height: 1.6;
+    padding: 0 30px;
   `}
 
   ${media.largeTablet`

--- a/components/community.js
+++ b/components/community.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media, CTASecondary as BaseCTASecondary, SectionBase, SectionLeft, SectionRight, SectionRightInner } from "../utils";
+import { media, CTASecondary as BaseCTASecondary, SectionBase, SectionLeft, SectionRight, SectionRightInner, SectionDescription } from "../utils";
 
 const CommunityModule = styled(SectionBase)`
   background: #fff;
@@ -24,23 +24,7 @@ const CommunityTitle = styled.div`
   `}
 `;
 
-const CommunityDescription = styled.div`
-  color: #666666;
-  font-size: 16px;
-  line-height: 1.4;
-  padding: 0 30px;
-  font-weight: 400;
-  max-width: 800px;
-  text-align: center;
-  letter-spacing: -1px;
-  margin: 20px auto 0 auto;
-
-  ${media.tablet`
-    padding: 0;
-    font-size: 20px;
-    line-height: 1.6;
-  `}
-`;
+const CommunityDescription = SectionDescription;
 
 const CommunityIntro = styled.p`
   color: #f38800;

--- a/components/paths.js
+++ b/components/paths.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { media, SectionBase } from '../utils';
+import { media, SectionBase, SectionDescription } from '../utils';
 
 const PathsModule = styled(SectionBase)`
   background: #fff;
@@ -23,23 +23,6 @@ const PathsTitle = styled.div`
   `}
 `;
 
-const PathsDescription = styled.div`
-  color: #666666;
-  font-size: 16px;
-  line-height: 1.4;
-  padding: 0 30px;
-  font-weight: 400;
-  max-width: 800px;
-  text-align: center;
-  letter-spacing: -1px;
-  margin: 20px auto 0 auto;
-
-  ${media.tablet`
-    padding: 0;
-    font-size: 20px;
-    line-height: 1.6;
-  `}
-`;
 
 const PathsCardGrid = styled.div`
   display: flex;
@@ -168,9 +151,9 @@ export const Paths = () => (
   <PathsModule>
     <PathsIntro>Developers & Shadowy Coders</PathsIntro>
     <PathsTitle>Integrates as fast as Lightning</PathsTitle>
-    <PathsDescription>
+    <SectionDescription>
       We’ve made it exceedingly straightforward to start supporting Lightning Addresses on your own domain or integrate them with the apps you’re building. Set up support for this new standard today and join the era of total Lightning interoperability!
-    </PathsDescription>
+    </SectionDescription>
     <PathsCardGrid>
       {(IMPLEMENTATIONS || []).map((benefit) => (
         <PathsCard key={benefit.title}>

--- a/utils.js
+++ b/utils.js
@@ -101,3 +101,21 @@ export const CTASecondary = styled.a`
     margin: 0 0 0 15px;
   `}
 `;
+
+export const SectionDescription = styled.div`
+  color: #666666;
+  font-size: 16px;
+  line-height: 1.4;
+  padding: 0 30px;
+  font-weight: 400;
+  max-width: 800px;
+  text-align: center;
+  letter-spacing: -1px;
+  margin: 20px auto 0 auto;
+
+  ${media.tablet`
+    padding: 0;
+    font-size: 20px;
+    line-height: 1.6;
+  `}
+`;


### PR DESCRIPTION
## Summary

`BenefitsDescription` (in `benefits.js`), `PathsDescription` (in `paths.js`), and `CommunityDescription` (in `community.js`) were nearly identical styled components — same color, font-size, line-height, padding, font-weight, max-width, text-align, letter-spacing, margin, and responsive tablet breakpoint. This extracts them to `utils.js` as a shared `SectionDescription` component.

`BenefitsDescription` has a slightly different tablet behavior (no `padding: 0` reset at 768px, only at 920px+ via `largeTablet`), so it extends the shared base with its own media query overrides to preserve the exact original visual behavior.

This follows the same cleanup pattern established in prior PRs:
- PR #208 — shared `SectionBase`
- PR #242 — shared `ImageWrapper`
- PR #243 — shared `Card`

## Changes

| File | Change |
|------|--------|
| `utils.js` | Added shared `SectionDescription` styled component |
| `components/benefits.js` | Import shared `SectionDescription`; replaced local `BenefitsDescription` with extension adding `largeTablet` override |
| `components/paths.js` | Import shared `SectionDescription`; removed local `PathsDescription` |
| `components/community.js` | Import shared `SectionDescription`; replaced local `CommunityDescription` with alias |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes