### PR TITLE
refactor: extract shared SignUpButton styled component

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media, CTASecondary as BaseCTASecondary, SectionBase, SectionLeft, SectionRight, SectionRightInner } from "../utils";
+import { media, CTASecondary as BaseCTASecondary, SectionBase, SectionLeft, SectionRight, SectionRightInner, SignUpButton } from "../utils";
 
 const CommunityModule = styled(SectionBase)`
   background: #fff;
@@ -94,31 +94,6 @@ const CommunityCard = styled.div`
   `}
 `;
 
-const CommunitySignUpButton = styled.a`
-  color: #fff;
-  width: 140px;
-  height: 2.81rem;
-  cursor: pointer;
-  min-width: 220px;
-  padding: 0 0.5rem;
-  text-align: center;
-  border-radius: 7px;
-  margin: 15px 0 0 0;
-  line-height: 2.8rem;
-  text-decoration: none;
-  background-color: #0070f3;
-  box-shadow: 0 4px 14px 0 rgb(0 118 255 / 39%);
-
-  &:hover {
-    background: rgba(0,118,255,0.9);
-    box-shadow: 0 6px 20px rgb(0 118 255 / 23%);
-  }
-
-  ${media.tablet`
-    min-width: 220px;
-    margin: 0 15px 0 0;
-  `}
-`;
 
 const Image = styled.img`
   width: 130px;
@@ -552,9 +527,9 @@ export const Community = () => (
                 style={wallet.imageStyle || {}}
               />
             </ImageWrapper>
-            <CommunitySignUpButton target="_blank" rel="noopener noreferrer" href={wallet.url}>
+            <SignUpButton target="_blank" rel="noopener noreferrer" href={wallet.url}>
               {wallet.downloadText}
-            </CommunitySignUpButton>
+            </SignUpButton>
           </CommunityCard>
         ))}
         <CTAWrapper>

--- a/components/providers.js
+++ b/components/providers.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media, SectionBase, SectionLeft, SectionRight, SectionRightInner } from "../utils";
+import { media, SectionBase, SectionLeft, SectionRight, SectionRightInner, SignUpButton } from "../utils";
 
 const ProvidersModule = styled(SectionBase)`
   background: #fafafa;
@@ -136,33 +136,6 @@ const ProviderCard = styled.div`
   `}
 `;
 
-const ProviderSignUpButton = styled.a`
-  color: #fff;
-  width: 140px;
-  height: 2.81rem;
-  cursor: pointer;
-  min-width: 220px;
-  padding: 0 0.5rem;
-  text-align: center;
-  border-radius: 7px;
-  margin: 15px 0 0 0;
-  line-height: 2.8rem;
-  text-decoration: none;
-  background-color: #0070f3;
-  box-shadow: 0 4px 14px 0 rgb(0 118 255 / 39%);
-  opacity: ${({ isDisabled }) => (isDisabled ? "0.5" : "1")};
-
-  &:hover {
-    background: ${({ isDisabled }) =>
-      isDisabled ? "#0070f3" : "rgba(0,118,255,0.9)"};
-    box-shadow: 0 6px 20px rgb(0 118 255 / 23%);
-  }
-
-  ${media.tablet`
-    min-width: 220px;
-    margin: 0 15px 0 0;
-  `}
-`;
 
 const ImageWrapper = styled.div`
   display: flex;
@@ -434,14 +407,14 @@ export const Providers = () => (
               />
               <DomainURL>you@{provider.lightningAddressDomain}</DomainURL>
             </ImageWrapper>
-            <ProviderSignUpButton
+            <SignUpButton
               isDisabled={provider.comingSoon}
               target="_blank"
               rel="noopener noreferrer"
               href={provider.url}
             >
               {provider.buttonText || `Open ${provider.name}`}
-            </ProviderSignUpButton>
+            </SignUpButton>
           </ProviderCard>
         ))}
       </SectionLeft>

--- a/utils.js
+++ b/utils.js
@@ -101,3 +101,31 @@ export const CTASecondary = styled.a`
     margin: 0 0 0 15px;
   `}
 `;
+
+export const SignUpButton = styled.a`
+  color: #fff;
+  width: 140px;
+  height: 2.81rem;
+  cursor: pointer;
+  min-width: 220px;
+  padding: 0 0.5rem;
+  text-align: center;
+  border-radius: 7px;
+  margin: 15px 0 0 0;
+  line-height: 2.8rem;
+  text-decoration: none;
+  background-color: #0070f3;
+  box-shadow: 0 4px 14px 0 rgb(0 118 255 / 39%);
+  opacity: ${({ isDisabled }) => (isDisabled ? "0.5" : "1")};
+
+  &:hover {
+    background: ${({ isDisabled }) =>
+      isDisabled ? "#0070f3" : "rgba(0,118,255,0.9)"};
+    box-shadow: 0 6px 20px rgb(0 118 255 / 23%);
+  }
+
+  ${media.tablet`
+    min-width: 220px;
+    margin: 0 15px 0 0;
+  `}
+`;


### PR DESCRIPTION
## Summary

`CommunitySignUpButton` (in `community.js`) and `ProviderSignUpButton` (in `providers.js`) were nearly identical styled components — same color, width, height, padding, border-radius, margin, line-height, background-color, box-shadow, and responsive tablet breakpoint. The provider version also had an `isDisabled` prop for disabled styling. This extracts them to `utils.js` as a shared `SignUpButton` component that includes optional `isDisabled` prop support.

When `isDisabled` is not passed (as in the community section), `SignUpButton` behaves identically to the original `CommunitySignUpButton`.

This follows the same cleanup pattern established in prior PRs:
- PR #208 — shared `SectionBase`
- PR #242 — shared `ImageWrapper`
- PR #243 — shared `Card`

## Changes

| File | Change |
|------|--------|
| `utils.js` | Added shared `SignUpButton` styled component with optional `isDisabled` prop |
| `components/community.js` | Import shared `SignUpButton`; removed local `CommunitySignUpButton` |
| `components/providers.js` | Import shared `SignUpButton`; removed local `ProviderSignUpButton` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes