### PR TITLE
refactor: remove redundant CSS from hero.js Title and Intro media queries

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -32,8 +32,6 @@ const Title = styled.h1`
   ${media.tablet`
     padding: 0 20px;
     font-size: 84px;
-    max-width: 900px;
-    font-weight: 800;
     letter-spacing: -4px;
   `}
 `;
@@ -54,7 +52,6 @@ const Intro = styled.p`
   ${media.tablet`
     font-size: 18px;
     max-width: 900px;
-    line-height: 1.6;
   `}
 `;
 


### PR DESCRIPTION
## Summary\n\nThe `Title` styled component in hero.js had two properties in the `tablet` media query that duplicated the base values:\n- `max-width: 900px` — already set to the same value in the base element\n- `font-weight: 800` — already set to the same value in the base element\n\nSimilarly, the `Intro` styled component had `line-height: 1.6` in the `tablet` media query, which is already set in the base element.\n\nOnly the properties that actually change (`padding`, `font-size`, `letter-spacing` for `Title`; `font-size`, `max-width` for `Intro`) remain in their respective media queries.\n\n## Changes\n\n| File | Change |\n|------|--------|\n| `components/hero.js` | Removed redundant `max-width`, `font-weight` from `Title` tablet media query; removed redundant `line-height` from `Intro` tablet media query |\n\n## Test Plan\n\n- [x] Build passes clean (`npm run build`)\n- [x] No functional or visual changes