### PR TITLE
refactor: extract shared SectionIntro styled component

### DIFF
--- a/components/benefits.js
+++ b/components/benefits.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { media, CTAPrimary, SectionBase } from '../utils';
+import { media, CTAPrimary, SectionBase, SectionIntro } from '../utils';
 
 const BenefitsModule = styled(SectionBase)`
   background: #fafafa;
@@ -119,23 +119,6 @@ const BenefitsCardDescription = styled.div`
   text-align: center;
 `;
 
-const BenefitsIntro = styled.p`
-  color: #26a717;
-  font-size: 14px;
-  line-height: 1.6;
-  max-width: 900px;
-  font-weight: 500;
-  padding: 8px 12px;
-  border-radius: 7px;
-  margin: 0 auto 20px auto;
-  background: rgba(10,117,14,0.12);
-
-  ${media.tablet`
-    font-size: 18px;
-  `}
-`;
-
-
 const CTAWrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -167,7 +150,7 @@ const BENEFITS = [
 
 export const Benefits = () => (
   <BenefitsModule>
-    <BenefitsIntro>Users & Enthusiasts</BenefitsIntro>
+    <SectionIntro color="#26a717" bg="rgba(10,117,14,0.12)">Users & Enthusiasts</SectionIntro>
     <BenefitsTitle>Why do I need a Lightning Address?</BenefitsTitle>
     <BenefitsDescription>We created the Lightning Address protocol to empower everyone to send money like we send emails — instantly and abundantly. Coupled with the Lightning Network’s ability to send Bitcoin instantly and with (almost) no fees, we’re ushering in a new standard for how value moves around the world.</BenefitsDescription>
     <BenefitsCardGrid>

--- a/components/community.js
+++ b/components/community.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { media, CTASecondary as BaseCTASecondary, SectionBase, SectionLeft, SectionRight, SectionRightInner } from "../utils";
+import { media, CTASecondary as BaseCTASecondary, SectionBase, SectionIntro, SectionLeft, SectionRight, SectionRightInner } from "../utils";
 
 const CommunityModule = styled(SectionBase)`
   background: #fff;
@@ -39,22 +39,6 @@ const CommunityDescription = styled.div`
     padding: 0;
     font-size: 20px;
     line-height: 1.6;
-  `}
-`;
-
-const CommunityIntro = styled.p`
-  color: #f38800;
-  font-size: 14px;
-  line-height: 1.6;
-  max-width: 900px;
-  font-weight: 500;
-  padding: 8px 12px;
-  border-radius: 7px;
-  margin: 0 auto 20px auto;
-  background: rgba(255, 97, 0, 0.1);
-
-  ${media.tablet`
-    font-size: 18px;
   `}
 `;
 
@@ -525,7 +509,7 @@ const WALLETS = [
 
 export const Community = () => (
   <CommunityModule id="community">
-    <CommunityIntro>Community Efforts & Tools</CommunityIntro>
+    <SectionIntro>Community Efforts & Tools</SectionIntro>
     <CommunityTitle>Noncustodial Bridge Servers</CommunityTitle>
     <CommunityDescription>
       The Lightning Address standard continues to be adopted by community

--- a/components/paths.js
+++ b/components/paths.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { media, SectionBase } from '../utils';
+import { media, SectionBase, SectionIntro } from '../utils';
 
 const PathsModule = styled(SectionBase)`
   background: #fff;
@@ -118,22 +118,6 @@ const PathsCardButton = styled.a`
   }
 `;
 
-const PathsIntro = styled.p`
-  color: #f38800;
-  font-size: 14px;
-  line-height: 1.6;
-  max-width: 900px;
-  font-weight: 500;
-  padding: 8px 12px;
-  border-radius: 7px;
-  margin: 0 auto 20px auto;
-  background: rgba(255,97,0,0.1);
-
-  ${media.tablet`
-    font-size: 18px;
-  `}
-`;
-
 const IMPLEMENTATIONS = [
   {
     title: 'Apps & Services',
@@ -166,7 +150,7 @@ const IMPLEMENTATIONS = [
 
 export const Paths = () => (
   <PathsModule>
-    <PathsIntro>Developers & Shadowy Coders</PathsIntro>
+    <SectionIntro>Developers & Shadowy Coders</SectionIntro>
     <PathsTitle>Integrates as fast as Lightning</PathsTitle>
     <PathsDescription>
       We’ve made it exceedingly straightforward to start supporting Lightning Addresses on your own domain or integrate them with the apps you’re building. Set up support for this new standard today and join the era of total Lightning interoperability!

--- a/utils.js
+++ b/utils.js
@@ -78,6 +78,22 @@ export const CTAPrimary = styled.a`
   `}
 `;
 
+export const SectionIntro = styled.p`
+  font-size: 14px;
+  line-height: 1.6;
+  max-width: 900px;
+  font-weight: 500;
+  padding: 8px 12px;
+  border-radius: 7px;
+  margin: 0 auto 20px auto;
+  color: ${({ color }) => color || '#f38800'};
+  background: ${({ bg }) => bg || 'rgba(255,97,0,0.1)'};
+
+  ${media.tablet`
+    font-size: 18px;
+  `}
+`;
+
 export const CTASecondary = styled.a`
   color: #696969;
   cursor: pointer;


### PR DESCRIPTION
## Summary

`BenefitsIntro` (in `benefits.js`), `PathsIntro` (in `paths.js`), and `CommunityIntro` (in `community.js`) were nearly identical styled components — same font-size, line-height, max-width, font-weight, padding, border-radius, margin, and responsive tablet breakpoint. Only the color and background-color differed. This extracts them to `utils.js` as a shared `SectionIntro` component with `color` and `bg` props for the differing values.

- `PathsIntro` and `CommunityIntro` were identical (same `#f38800` color and `rgba(255,97,0,0.1)` background) — they use the shared defaults.
- `BenefitsIntro` uses green (`#26a717` / `rgba(10,117,14,0.12)`) — passed as props.

This follows the same cleanup pattern established in prior PRs:
- PR #208 — shared `SectionBase`
- PR #242 — shared `ImageWrapper`
- PR #243 — shared `Card`
- PR #247 — shared `SectionTitle`
- PR #248 — shared `SectionDescription`

## Changes

| File | Change |
|------|--------|
| `utils.js` | Added shared `SectionIntro` styled component with `color` and `bg` props |
| `components/benefits.js` | Import shared `SectionIntro` with green color props; removed local `BenefitsIntro` |
| `components/paths.js` | Import shared `SectionIntro`; removed local `PathsIntro` |
| `components/community.js` | Import shared `SectionIntro`; removed local `CommunityIntro` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes