### PR TITLE
perf: load Google Fonts via <link> in _document.js instead of @import in createGlobalStyle

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,8 +1,6 @@
 import { createGlobalStyle, ThemeProvider } from 'styled-components'
 
 const GlobalStyle = createGlobalStyle`
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@200;400;500;700;900&display=swap');
-
   body {
     margin: 0;
     padding: 0;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -31,7 +31,12 @@ export default class MyDocument extends Document {
   render() {
     return (
       <Html lang="en">
-        <Head />
+        <Head>
+          <link
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@200;400;500;700;900&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
## Summary

The Inter font was loaded via `@import url()` inside a styled-components `createGlobalStyle` block. This approach has the browser discover the font stylesheet only after JavaScript executes and React renders the global style, which can cause a flash of unstyled text (FOUC).

Moving the font stylesheet to a `<link>` tag in `_document.js` allows the browser to start fetching the font CSS immediately during HTML parsing, before any JavaScript runs.

```diff
- // _app.js: CSS @import inside createGlobalStyle (loaded after JS executes)
- @import url('https://fonts.googleapis.com/css2?family=Inter:wght@200;400;500;700;900&display=swap');

+ // _document.js: <link> tag in <Head> (loaded during HTML parsing)
+ <link href="..." rel="stylesheet" />
```

The `body { font-family: 'Inter', sans-serif; }` declaration in `createGlobalStyle` is preserved unchanged, so the font is still used when it finishes loading — the only difference is `when` the browser starts loading it.

## Changes

| File | Change |
|------|--------|
| `pages/_app.js` | Removed `@import url()` from `createGlobalStyle` |
| `pages/_document.js` | Added `<link rel=\stylesheet\>` to `<Head>` for Inter font |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] Font loads and renders correctly in the browser