### PR TITLE
refactor: remove dead comingSoon: false fields from providers.js

### DIFF
--- a/components/providers.js
+++ b/components/providers.js
@@ -289,7 +289,6 @@ const PROVIDERS = [
     lightningAddressDomain: "noah.me",
     url: "https://app.noah.com",
     buttonText: "Claim Address",
-    comingSoon: false,
   },
   {
     name: "Bitnob",
@@ -306,7 +305,6 @@ const PROVIDERS = [
     lightningAddressDomain: "8333.mobi",
     url: "https://8333.mobi",
     buttonText: "Dial Machankura",
-    comingSoon: false,
   },
   {
     name: "Mash",


### PR DESCRIPTION
## Summary

Two provider entries (`Noah` and `Machankura`) in the `PROVIDERS` array had explicit `comingSoon: false` fields. Since the only usage of this field is `isDisabled={provider.comingSoon}` on `ProviderSignUpButton`, and `false` is falsy, this produces the exact same behavior as omitting the field entirely (which all other providers do). These are dead data fields that add unnecessary noise.

## Changes

| File | Change |
|------|--------|
| `components/providers.js` | Removed `comingSoon: false` from `Noah` and `Machankura` entries |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes — `isDisabled={undefined}` and `isDisabled={false}` behave identically in React