### PR TITLE
fix(docs): add missing LNMarkets entry to README wallet table

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ _Bitcoin Lightning wallets that support sending and receiving to **Lightning Add
 | [Lexe](https://lexe.app/)                                         | ☑️        | ☑️        |
 | [LifPay](https://lifpay.me/)                                      | ☑️        | ☑️        |
 | [LNbits](https://lnbits.org/)                                     | ☑️        | WIP       |
+| [LNMarkets](https://lnmarkets.com/)                               | ☑️        | ☑️        |
 | [@lntxbot](https://lntxbot.com/)                                  | ☑️        | ☑️        |
 | [Machankura](https://8333.mobi/)                                  | ☑️        | ☑️        |
 | [Mash](https://getmash.com/)                                      | ----      | ☑️        |


### PR DESCRIPTION
## Summary

LNMarkets supports Lightning Addresses (both sending and receiving) and is listed as a provider on the website in `providers.js`, as well as in both the Sending and Receiving footer sections. However, it was missing from the README wallet table entirely.

This adds LNMarkets between `LNbits` and `@lntxbot` in the correct case-insensitive alphabetical position (L-N-M vs L-N-b: `M` sorts before `b` in ASCII).

## Changes

| File | Change |
|------|--------|
| `README.md` | Added `LNMarkets` row with ☑️ for both Sending and Receiving |

## Test Plan

- [x] Visual inspection confirms table alignment is consistent with surrounding rows
- [x] No functional or visual changes to the site