### PR TITLE
refactor: remove redundant min-width from SignUpButton tablet media queries

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -115,7 +115,6 @@ const CommunitySignUpButton = styled.a`
   }
 
   ${media.tablet`
-    min-width: 220px;
     margin: 0 15px 0 0;
   `}
 `;

--- a/components/providers.js
+++ b/components/providers.js
@@ -159,7 +159,6 @@ const ProviderSignUpButton = styled.a`
   }
 
   ${media.tablet`
-    min-width: 220px;
     margin: 0 15px 0 0;
   `}
 `;


### PR DESCRIPTION
## Summary

Both `CommunitySignUpButton` (`community.js`) and `ProviderSignUpButton` (`providers.js`) declared `min-width: 220px` inside the `${media.tablet`...`}` block — but the same `min-width: 220px` is already set in the base style for both components. Since the property value doesn't change between breakpoints, the media-query declaration is dead code.

Each component now has a single `min-width: 220px` declaration at the base level, which correctly applies at all screen widths.

## Changes

| File | Line | Change |
|------|------|--------|
| `components/community.js` | 118 | Removed `min-width: 220px` from tablet media query |
| `components/providers.js` | 162 | Removed `min-width: 220px` from tablet media query |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes — both buttons render identically