### PR TITLE
refactor: remove redundant font-size and line-height from Link tablet media query

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -180,9 +180,7 @@ const Link = styled.a`
   background: rgba(0, 118, 255, 0.1);
 
   ${media.tablet`
-    font-size: 14px;
     max-width: 900px;
-    line-height: 1.6;
   `}
 
   &:hover {


### PR DESCRIPTION
## Summary

The `Link` styled component in `community.js` declares `font-size: 14px` and `line-height: 1.6` at the base level, and then repeats the exact same values in the `tablet` (768px+) media query. Since the values don't change between breakpoints, the media-query declarations are dead code.

The only declaration that actually changes on tablet is `max-width: 900px`, which is preserved.

## Changes

| File | Change |
|------|--------|
| `components/community.js` | Removed `font-size: 14px` and `line-height: 1.6` from `Link` tablet media query |

## Test Plan
- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes — both properties inherit from the base declaration