### PR TITLE
refactor: remove redundant text-align from CommunityDescriptionSmall

### DIFF
--- a/components/community.js
+++ b/components/community.js
@@ -200,8 +200,6 @@ const VerticalLink = styled(Link)`
 `;
 
 const CommunityDescriptionSmall = styled(CommunityDescription)`
-  text-align: center;
-
   ${media.tablet`
     text-align: left;
     font-size: 18px;


### PR DESCRIPTION
## Summary

`CommunityDescriptionSmall` in `community.js` is defined as `styled(CommunityDescription)` — it extends the `CommunityDescription` component, which already declares `text-align: center` at the base level. The `text-align: center` in `CommunityDescriptionSmall`'s own base styles is therefore redundant, since the property is inherited from the parent component.

### Before
```js
const CommunityDescriptionSmall = styled(CommunityDescription)`
  text-align: center;

  ${media.tablet`
    text-align: left;
    font-size: 18px;
  `}
`;
```

### After
```js
const CommunityDescriptionSmall = styled(CommunityDescription)`
  ${media.tablet`
    text-align: left;
    font-size: 18px;
  `}
`;
```

## Changes

| File | Change |
|------|--------|
| `components/community.js` | Removed redundant `text-align: center` from `CommunityDescriptionSmall` base declaration |

## Test Plan
- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes — the text-align value is inherited unchanged from `CommunityDescription`