### PR TITLE
fix: align Google Font weights with actual CSS usage

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,7 @@
 import { createGlobalStyle, ThemeProvider } from 'styled-components'
 
 const GlobalStyle = createGlobalStyle`
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@200;400;500;700;900&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
 
   body {
     margin: 0;


### PR DESCRIPTION
## Summary

The Google Fonts URL for Inter requested `wght@200;400;500;700;900`, but the codebase only uses weights 400, 500, 600, 700, and 800. Two weights were missing (600, 800) and two were downloaded unnecessarily (200, 900).

### What changed

Updated the font URL in `pages/_app.js` from `wght@200;400;500;700;900` to `wght@400;500;600;700;800`.

### Why it matters

- **Visual correctness**: Title text (800 weight) and card titles (600 weight) now render with the intended font weight instead of falling back to 700/500
- **Performance**: Two unnecessary font weight files (200, 900) are no longer downloaded

### Font-weight usage in codebase

| Weight | Usage count | Was in URL? |
|--------|------------|-------------|
| 400     | 11×        | ✅ Yes     |
| 500     | 6×         | ✅ Yes     |
| **600** | **4×**     | ❌ **No**  |
| 700     | 1×         | ✅ Yes     |
| **800** | **8×**     | ❌ **No**  |
| ~~200~~ | 0×         | ❌ Removed |
| ~~900~~ | 0×         | ❌ Removed |

### Test Plan

- [x] Build passes clean (`npm run build`)
- [x] Visual check confirms title and card text render at the correct weight

Closes: — (complements PR #252 font-loading optimization)