### PR TITLE
refactor: remove redundant color from LicenseLink hover in hero.js

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -147,7 +147,6 @@ const LicenseLink = styled.a`
   text-decoration: none;
 
   &:hover {
-    color: #0070f3;
     background: rgba(0,118,255,0.1);
   }
 `;


### PR DESCRIPTION
## Summary

The `LicenseLink` styled component in `hero.js` declares `color: #0070f3` in its base styles and again in the `&:hover` block. Since the color doesn't change on hover, the hover declaration is identical to base and has no effect.

### Before

```js
const LicenseLink = styled.a`
  padding: 8px;
  color: #0070f3;
  margin-left: 4px;
  font-weight: 400;
  border-radius: 7px;
  text-decoration: none;

  &:hover {
    color: #0070f3;
    background: rgba(0,118,255,0.1);
  }
```;

### After

```js
const LicenseLink = styled.a`
  padding: 8px;
  color: #0070f3;
  margin-left: 4px;
  font-weight: 400;
  border-radius: 7px;
  text-decoration: none;

  &:hover {
    background: rgba(0,118,255,0.1);
  }
```;

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual change — the color value is inherited from the base declaration