### PR TITLE
refactor: remove dead isSecondary: false from paths.js IMPLEMENTATIONS entry

### DIFF
--- a/components/paths.js
+++ b/components/paths.js
@@ -141,7 +141,6 @@ const IMPLEMENTATIONS = [
     image: '/images/data4.svg',
     linkText: 'Get Started',
     link: '#providers',
-    isSecondary: false,
     isInternal: true,
   },
   {


### PR DESCRIPTION
## Summary

The first `IMPLEMENTATIONS` entry in `paths.js` had `isSecondary: false` explicitly set. Since `undefined` (when the field is omitted) is also falsy, this produces the exact same behavior. Removing it cleans up dead data.

This follows the same cleanup pattern applied to `providers.js` in PR #253, where `comingSoon: false` was removed for the same reason.

### Changes

| File | Change |
|------|--------|
| `components/paths.js` | Removed `isSecondary: false` from the first `IMPLEMENTATIONS` entry (Apps & Services) |

### Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes — `isSecondary={undefined}` and `isSecondary={false}` behave identically in React (both are falsy)