### PR TITLE
chore: add robots.txt for search engine crawling

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://lightningaddress.com/sitemap.xml


### PR DESCRIPTION
## Summary\n\nThe site was missing a `robots.txt` file at the expected location (`/robots.txt`). While Next.js serves the page without it, search engine crawlers and SEO tools expect this file to be present for indexing instructions.\n\nThis adds a standard robots.txt that:\n- Allows all well-behaved crawlers (`Allow: /`)\n- References the sitemap at `https://lightningaddress.com/sitemap.xml`\n\n## Changes\n\n| File | Change |\n|------|--------|\n| `public/robots.txt` | New file — standard robots.txt allowing all crawlers, referencing sitemap |\n\n## Test Plan\n\n- [x] Build passes clean (`npm run build`)\n- [x] No functional or visual changes — robots.txt is only consumed by crawlers, not the browser