### PR TITLE
refactor: combine duplicate margin declarations in BenefitsCard

### DIFF
--- a/components/benefits.js
+++ b/components/benefits.js
@@ -64,12 +64,11 @@ const BenefitsCard = styled.div`
   width: 70%;
   padding: 20px;
   display: flex;
-  margin: 0 auto;
+  margin: 0 auto 20px;
   background: #fff;
   min-height: 300px;
   border-radius: 7px;
   align-items: center;
-  margin-bottom: 20px;
   flex-direction: column;
   border: 1px solid #eaeaea;
   transition: box-shadow .2s ease;


### PR DESCRIPTION
## Summary\n\nThe `BenefitsCard` component in `benefits.js` declared `margin: 0 auto` (setting all four margins to top:0, right:auto, bottom:0, left:auto) and then immediately overrode `margin-bottom` to `20px`. The `margin-bottom: 0` from the shorthand was dead code.\n\n### Before\n\n```css\nmargin: 0 auto;\n/* ... other declarations ... */\nmargin-bottom: 20px;\n```\n\n### After\n\n```css\nmargin: 0 auto 20px;\n```\n\nThe shorthand `margin: 0 auto 20px` sets top: 0, right: auto, bottom: 20px, left: auto — identical behavior.\n\n## Changes\n\n| File | Change |\n|------|--------|\n| `components/benefits.js` | Combined `margin: 0 auto` + `margin-bottom: 20px` into `margin: 0 auto 20px` |\n\n## Test Plan\n\n- [x] Build passes clean (`npm run build`)\n- [x] No functional or visual changes — the shorthand produces identical computed styles