### PR TITLE
refactor: remove redundant CSS from Description tablet media query in hero.js

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -76,11 +76,9 @@ const Description = styled.p`
   margin: 20px auto 0 auto;
 
   ${media.tablet`
-    padding: 0;
     font-size: 20px;
     padding: 0 30px;
     max-width: 500px;
-    line-height: 1.4;
     letter-spacing: -1px;
   `}
 `;


### PR DESCRIPTION
## Summary

The `Description` styled component in `hero.js` declared two properties in the `tablet` media query that were redundant:

- `padding: 0;` was immediately overridden by `padding: 0 30px;` on the next line — the first declaration had no effect.
- `line-height: 1.4;` was identical to the base declaration.

### Before

```js
${media.tablet`
    padding: 0;
    font-size: 20px;
    padding: 0 30px;
    max-width: 500px;
    line-height: 1.4;
    letter-spacing: -1px;
`}
```

### After

```js
${media.tablet`
    font-size: 20px;
    padding: 0 30px;
    max-width: 500px;
    letter-spacing: -1px;
`}
```

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes — the effective computed styles are identical