### PR TITLE
refactor: remove redundant transition from BenefitsCard and PathsCard hover styles

### DIFF
--- a/components/benefits.js
+++ b/components/benefits.js
@@ -80,7 +80,6 @@ const BenefitsCard = styled.div`
 
   &:hover {
     border: 1px solid #ccc;
-    transition: box-shadow .2s ease;
     box-shadow: 0 8px 30px rgba(0,0,0,0.12);
   }
 `;

--- a/components/paths.js
+++ b/components/paths.js
@@ -69,7 +69,6 @@ const PathsCard = styled.div`
 
   &:hover {
     border: 1px solid #ccc;
-    transition: box-shadow .2s ease;
     box-shadow: 0 8px 30px rgba(0,0,0,0.12);
   }
 


### PR DESCRIPTION
## Summary

Both `BenefitsCard` (`benefits.js`) and `PathsCard` (`paths.js`) declared `transition: box-shadow .2s ease` in their base styled components **and** again in their `&:hover` blocks. Since the base already applies the transition to all state changes (including hover), the hover declaration has no effect and is dead code.

### BenefitsCard hover (before → after)

```diff
   &:hover {
     border: 1px solid #ccc;
-    transition: box-shadow .2s ease;
     box-shadow: 0 8px 30px rgba(0,0,0,0.12);
   }
```

### PathsCard hover (before → after)

```diff
   &:hover {
     border: 1px solid #ccc;
-    transition: box-shadow .2s ease;
     box-shadow: 0 8px 30px rgba(0,0,0,0.12);
   }
```

## Changes

| File | Change |
|------|--------|
| `components/benefits.js` | Removed `transition: box-shadow .2s ease` from `BenefitsCard` hover block |
| `components/paths.js` | Removed `transition: box-shadow .2s ease` from `PathsCard` hover block |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes — the base declaration ensures the transition is still applied on hover