### PR TITLE
refactor: simplify SectionBase padding shorthand in utils.js

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -23,12 +23,12 @@ export const SectionBase = styled.div`
   display: flex;
   align-items: center;
   flex-direction: column;
-  padding: 60px 0 60px 0;
+  padding: 60px 0;
   justify-content: center;
 
   ${media.tablet`
     min-height: 700px;
-    padding: 120px 0 120px 0;
+    padding: 120px 0;
   `}
 `;
 


### PR DESCRIPTION
## Summary

The `SectionBase` styled component used full 4-value padding shorthands where 2-value shorthands would suffice, since top/bottom and left/right values were identical.

### Before

```css
padding: 60px 0 60px 0;   /* top:60, right:0, bottom:60, left:0 */
padding: 120px 0 120px 0; /* top:120, right:0, bottom:120, left:0 */
```

### After

```css
padding: 60px 0;   /* top/bottom:60, left/right:0 */
padding: 120px 0;  /* top/bottom:120, left/right:0 */
```

## Changes

| File | Change |
|------|--------|
| `utils.js` | Simplified `padding: 60px 0 60px 0` to `padding: 60px 0` and `padding: 120px 0 120px 0` to `padding: 120px 0` |

## Test Plan

- [x] Build passes clean (`npm run build`)
- [x] No functional or visual changes — the shorthand produces identical computed styles